### PR TITLE
refactor!: markNotificationAsRead takes notification_id + kind

### DIFF
--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -241,7 +241,11 @@ export abstract class BaseClient {
   abstract markAllAsRead(options?: RequestOptions): Promise<void>;
 
   abstract markNotificationAsRead(
-    payload: { notification: types.Notification; read: boolean },
+    payload: {
+      kind: types.NotificationDataType;
+      notification_id: number;
+      read: boolean;
+    },
     options?: RequestOptions,
   ): Promise<void>;
 

--- a/src/providers/lemmyv0/index.ts
+++ b/src/providers/lemmyv0/index.ts
@@ -700,11 +700,11 @@ export class UnsafeLemmyV0Client implements BaseClient {
     payload: Parameters<BaseClient["markNotificationAsRead"]>[0],
     options?: RequestOptions,
   ): ReturnType<BaseClient["markNotificationAsRead"]> {
-    const { notification, read } = payload;
-    switch (notification.kind) {
+    const { kind, notification_id, read } = payload;
+    switch (kind) {
       case "mention":
         await this.#client.markPersonMentionAsRead(
-          { person_mention_id: notification.id, read },
+          { person_mention_id: notification_id, read },
           options,
         );
         return;
@@ -713,13 +713,13 @@ export class UnsafeLemmyV0Client implements BaseClient {
         return;
       case "private_message":
         await this.#client.markPrivateMessageAsRead(
-          { private_message_id: notification.id, read },
+          { private_message_id: notification_id, read },
           options,
         );
         return;
       case "reply":
         await this.#client.markCommentReplyAsRead(
-          { comment_reply_id: notification.id, read },
+          { comment_reply_id: notification_id, read },
           options,
         );
         return;

--- a/src/providers/lemmyv1/index.ts
+++ b/src/providers/lemmyv1/index.ts
@@ -607,7 +607,7 @@ export class UnsafeLemmyV1Client implements BaseClient {
   ): ReturnType<BaseClient["markNotificationAsRead"]> {
     await unwrap(
       await this.#client.markNotificationAsRead(
-        { notification_id: payload.notification.id, read: payload.read },
+        { notification_id: payload.notification_id, read: payload.read },
         options,
       ),
     );

--- a/src/providers/piefed/index.ts
+++ b/src/providers/piefed/index.ts
@@ -781,13 +781,13 @@ export class UnsafePiefedClient implements BaseClient {
     payload: Parameters<BaseClient["markNotificationAsRead"]>[0],
     options?: RequestOptions,
   ): ReturnType<BaseClient["markNotificationAsRead"]> {
-    const { notification, read } = payload;
-    switch (notification.kind) {
+    const { kind, notification_id, read } = payload;
+    switch (kind) {
       case "mention":
       case "reply":
         await this.#client.POST("/api/alpha/comment/mark_as_read", {
           ...options,
-          body: { comment_reply_id: notification.id, read },
+          body: { comment_reply_id: notification_id, read },
         });
         return;
       case "mod_action":
@@ -796,7 +796,7 @@ export class UnsafePiefedClient implements BaseClient {
       case "private_message":
         await this.#client.POST("/api/alpha/private_message/mark_as_read", {
           ...options,
-          body: { private_message_id: notification.id, read },
+          body: { private_message_id: notification_id, read },
         });
         return;
     }


### PR DESCRIPTION
## Summary

The current `markNotificationAsRead({ notification, read })` signature forces callers to hand in a full `Notification` object even though every provider only consumes `kind` and `id`. Callers who only know "I want to mark PM #42 read" have to fabricate a `Notification` with bogus `creator_id`, `published_at`, etc. just to satisfy the type.

Change the signature to the honest minimum:

```ts
markNotificationAsRead({ kind: NotificationDataType; notification_id: number; read: boolean })
```

All three providers' implementations only touch those two fields, so it's a pure simplification — no behavior change.

## Test plan

- [x] `pnpm test:types` clean
- [x] `pnpm test` — 19 / 19 pass
- [x] `pnpm format:check` clean

## Breaking

Consumers using `client.markNotificationAsRead({ notification, read })` need to switch to `{ kind: notification.kind, notification_id: notification.id, read }`. (Voyager PR follow-up.)