### PR TITLE
feat: post tags (Lemmy v1 + PieFed)

### DIFF
--- a/src/providers/lemmyv0/compat.ts
+++ b/src/providers/lemmyv0/compat.ts
@@ -636,6 +636,7 @@ export function toPostView(v: LemmyV0.PostView): types.PostView {
     read: v.read,
     saved: v.saved,
     subscribed: v.subscribed,
+    tags: [],
     unread_comments: v.unread_comments,
   };
 }

--- a/src/providers/piefed/compat.ts
+++ b/src/providers/piefed/compat.ts
@@ -255,6 +255,10 @@ export function toPostView(
     read: v.read,
     saved: v.saved,
     subscribed: toSubscribedType(v.subscribed),
+    tags: (v.flair_list ?? []).map((f) => ({
+      color: f.background_color,
+      name: f.flair_title,
+    })),
     unread_comments: v.counts.comments,
   };
 }

--- a/src/schemas/PostTag.ts
+++ b/src/schemas/PostTag.ts
@@ -1,0 +1,19 @@
+import { z } from "zod/v4-mini";
+
+/**
+ * A tag attached to a post.
+ *
+ * - Lemmy v1: maps from `CommunityTag` (mod-curated, palette color slot like
+ *   `"color03"`).
+ * - PieFed: maps from `CommunityFlair` applied to the post (hex `color`
+ *   like `"#a91b9c"`).
+ * - Lemmy v0: not supported (empty array).
+ *
+ * `color` is opaque to threadiverse — consumers either render it directly
+ * (hex) or look it up in a palette (Lemmy v1 slot keys).
+ */
+export const PostTag = z.object({
+  color: z.optional(z.string()),
+  display_name: z.optional(z.string()),
+  name: z.string(),
+});

--- a/src/schemas/PostView.ts
+++ b/src/schemas/PostView.ts
@@ -4,6 +4,7 @@ import { Community } from "./Community";
 import { Person } from "./Person";
 import { Post } from "./Post";
 import { PostNotificationsMode } from "./PostNotificationsMode";
+import { PostTag } from "./PostTag";
 import { SubscribedType } from "./SubscribedType";
 import { Vote } from "./Vote";
 
@@ -22,5 +23,6 @@ export const PostView = z.object({
   read: z.boolean(),
   saved: z.boolean(),
   subscribed: SubscribedType,
+  tags: z.array(PostTag),
   unread_comments: z.number(),
 });

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -36,6 +36,7 @@ export * from "./Post";
 export * from "./PostNotificationsMode";
 export * from "./PostReport";
 export * from "./PostReportView";
+export * from "./PostTag";
 export * from "./PostView";
 export * from "./PrivateMessage";
 export * from "./PrivateMessageView";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,6 +83,7 @@ export type PostNotificationsMode = z.infer<
 >;
 export type PostReport = z.infer<typeof schemas.PostReport>;
 export type PostReportView = z.infer<typeof schemas.PostReportView>;
+export type PostTag = z.infer<typeof schemas.PostTag>;
 export type PostView = z.infer<typeof schemas.PostView>;
 export type PrivateMessage = z.infer<typeof schemas.PrivateMessage>;
 export type PrivateMessageView = z.infer<typeof schemas.PrivateMessageView>;


### PR DESCRIPTION
## Summary

- Surface per-post tags on `PostView.tags` as a portable `PostTag[]` shape (`{ name, display_name?, color? }`) so consumers can render them uniformly across backends.
- Lemmy v1: maps each `CommunityTag` on `PostView.tags`. `color` is the palette slot (e.g. `"color03"`).
- PieFed: maps `PostView.flair_list[]` (`CommunityFlair`). `color` is the hex `background_color` (e.g. `"#a91b9c"`).
- Lemmy v0: `tags: []`.

`color` is opaque to threadiverse — consumers either render it directly (hex) or resolve it via a palette (Lemmy v1). The minimal shape deliberately skips v1-specific housekeeping (`id`, `ap_id`, `published_at`, `deleted`, `community_id`); those don't have PieFed analogs and aren't useful for view-only rendering. Mutation APIs (assign-tag / assign-flair) can grow their own richer types when added.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test:types`
- [x] `pnpm test` (23 existing tests pass)
- [x] Verified against `voyager.lemmy.ml` (Lemmy v1) — `PostView.tags` populated from `CommunityTag`
- [x] Verified against `piefed.social` (`c/fediverse`, `c/polls`) — `PostView.tags` populated from `flair_list`