### PR TITLE
feat: tags and notifications on PostReportView

### DIFF
--- a/src/providers/lemmyv0/compat.ts
+++ b/src/providers/lemmyv0/compat.ts
@@ -609,6 +609,7 @@ export function toPostReportView(
     creator_is_moderator: v.creator_is_moderator,
     hidden: v.hidden,
     my_vote: toVote(v.my_vote),
+    notifications: "replies_and_mentions",
     post: toPost(v.post, v.counts),
     post_creator: toPerson(v.post_creator),
     post_report: toPostReport(v.post_report),
@@ -616,6 +617,7 @@ export function toPostReportView(
     resolver: v.resolver ? toPerson(v.resolver) : undefined,
     saved: v.saved,
     subscribed: v.subscribed,
+    tags: [],
     unread_comments: v.unread_comments,
   };
 }

--- a/src/providers/lemmyv1/compat.ts
+++ b/src/providers/lemmyv1/compat.ts
@@ -136,9 +136,13 @@ export function toPostReportView(
     creator_blocked: !!v.person_actions?.blocked_at,
     hidden: !!v.post_actions?.hidden_at,
     my_vote: toVote(v.post_actions),
+    notifications: v.post_actions?.notifications ?? "replies_and_mentions",
     read: !!v.post_actions?.read_at,
     saved: !!v.post_actions?.saved_at,
     subscribed: toFollowState(v.community_actions?.follow_state),
+    // Lemmy v1 PostReportView doesn't carry tags. See
+    // https://github.com/LemmyNet/lemmy/issues/6527
+    tags: [],
     unread_comments: toUnreadComments(v.post, v.post_actions),
   };
 }

--- a/src/schemas/PostReportView.ts
+++ b/src/schemas/PostReportView.ts
@@ -3,7 +3,9 @@ import { z } from "zod/v4-mini";
 import { Community } from "./Community";
 import { Person } from "./Person";
 import { Post } from "./Post";
+import { PostNotificationsMode } from "./PostNotificationsMode";
 import { PostReport } from "./PostReport";
+import { PostTag } from "./PostTag";
 import { SubscribedType } from "./SubscribedType";
 import { Vote } from "./Vote";
 
@@ -19,6 +21,7 @@ export const PostReportView = z.object({
   creator_is_moderator: z.boolean(),
   hidden: z.boolean(),
   my_vote: z.optional(Vote),
+  notifications: PostNotificationsMode,
   post: Post,
   post_creator: Person,
   post_report: PostReport,
@@ -26,5 +29,6 @@ export const PostReportView = z.object({
   resolver: z.optional(Person),
   saved: z.boolean(),
   subscribed: SubscribedType,
+  tags: z.array(PostTag),
   unread_comments: z.number(),
 });


### PR DESCRIPTION
## Summary

Surface `notifications` and `tags` on `PostReportView`, mirroring `PostView`. Lets consumers (e.g. mod-queue UIs) render report posts through the same components without synthesizing missing fields.

- `notifications`: Lemmy v1 reads from `post_actions.notifications` (same as `toPostView`); v0/PieFed default to `replies_and_mentions`.
- `tags`: defaults to `[]` everywhere. Lemmy v1 upstream doesn't return tags on `PostReportView` yet — tracked at LemmyNet/lemmy#6527 (with an explanatory comment in `lemmyv1/compat.ts`). Internal tracker: #41.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test:types`
- [x] `pnpm test` (23 existing tests pass)
- [x] Verified consumer (Voyager) drops synthetic `notifications` / `tags` from its `PostReportView → PostView` converter and still typechecks
