### PR TITLE
feat(lemmyv1): surface read_comments_at on PostView

### DIFF
--- a/src/providers/lemmyv1/compat.ts
+++ b/src/providers/lemmyv1/compat.ts
@@ -156,6 +156,7 @@ export function toPostView(v: LemmyV1.PostView): types.PostView {
     my_vote: toVote(v.post_actions),
     notifications: v.post_actions?.notifications ?? "replies_and_mentions",
     read: !!v.post_actions?.read_at,
+    read_comments_at: nullToUndef(v.post_actions?.read_comments_at),
     saved: !!v.post_actions?.saved_at,
     subscribed: toFollowState(v.community_actions?.follow_state),
     unread_comments: toUnreadComments(v.post, v.post_actions),

--- a/src/schemas/PostView.ts
+++ b/src/schemas/PostView.ts
@@ -21,6 +21,12 @@ export const PostView = z.object({
   notifications: PostNotificationsMode,
   post: Post,
   read: z.boolean(),
+  /**
+   * When the current user last read the comments on this post (ISO 8601).
+   * Comments published after this can be treated as unread. Only provided by
+   * providers that track it (Lemmy v1); `undefined` otherwise.
+   */
+  read_comments_at: z.optional(z.string()),
   saved: z.boolean(),
   subscribed: SubscribedType,
   tags: z.array(PostTag),

--- a/test/lemmyv1-compat.test.ts
+++ b/test/lemmyv1-compat.test.ts
@@ -107,6 +107,32 @@ describe("v1 compat - my_vote derivation", () => {
     } as any);
     expect(v.my_vote).toBeUndefined();
   });
+
+  it("PostView: surfaces read_comments_at from post_actions", () => {
+    const v = toPostView({
+      ...basePostView(),
+      post_actions: {
+        read_comments_amount: 1,
+        read_comments_at: NOW,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    expect(v.read_comments_at).toBe(NOW);
+  });
+
+  it("PostView: read_comments_at null/absent → undefined", () => {
+    const nulled = toPostView({
+      ...basePostView(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      post_actions: { read_comments_at: null as any },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    expect(nulled.read_comments_at).toBeUndefined();
+
+    const absent = toPostView(basePostView() as never);
+    expect(absent.read_comments_at).toBeUndefined();
+  });
 });
 
 describe("v1 compat - toSupportedNotificationView normalizes null id fields", () => {


### PR DESCRIPTION
## What

Surface `read_comments_at` as an optional field on `PostView`.

Lemmy v1 records the timestamp of the last time the current user read a post's comments in `post_actions.read_comments_at`. Until now the compat layer only *consumed* it inside `toUnreadComments` (to derive `unread_comments`) and discarded the raw value.

```ts
// schemas/PostView.ts
read_comments_at: z.optional(z.string()),
```
```ts
// providers/lemmyv1/compat.ts (toPostView)
read_comments_at: nullToUndef(v.post_actions?.read_comments_at),
```

## Why

It unlocks two client features (e.g. Voyager) that the count alone can't:

- **Distinguish never-opened posts from opened-with-new-comments.** `toUnreadComments` returns the *total* comment count when `read_comments_at` is unset, so `unread_comments > 0` alone can't tell "5 brand-new comments since I last read" from "5 comments, never opened". The raw timestamp lets clients gate the "N new" badge on `read_comments_at != null`.
- **Highlight individual unread comments** — comments whose `published_at` is newer than `read_comments_at`.

## Provider coverage

- **Lemmy v1** — populated from `post_actions.read_comments_at`.
- **Lemmy v0 / PieFed** — left `undefined`; neither exposes an equivalent read-comments timestamp.

## Notes

- Normalized via `nullToUndef`: v1 sends JSON `null` (not an omitted key) for unset fields on an existing `post_actions` row, and the schema is `z.optional(z.string())` (no `null`). This matches the existing `read_at` / vote / notification-id handling in the same file — `toUnreadComments` already guards `read_comments_at == null` for the same reason.

## Verification

- `pnpm test` (lint + types + vitest): **25 passed**, including 2 new `lemmyv1-compat` cases — surfaces the timestamp, and maps `null`/absent → `undefined`.
- Confirmed against a live `1.0.0-nightly` instance: `get_post` returns the pre-update `read_comments_at` (the boundary) and `/post/list` carries `post_actions.read_comments_at` per post.
