### PR TITLE
fix(piefed): surface own-profile post/comment counts in getSite

### DIFF
--- a/src/providers/piefed/index.ts
+++ b/src/providers/piefed/index.ts
@@ -579,6 +579,7 @@ export class UnsafePiefedClient implements BaseClient {
               },
               person: compat.toPerson(
                 response.data!.my_user.local_user_view.person,
+                response.data!.my_user.local_user_view.counts,
               ),
             },
             moderates: response.data!.my_user.moderates.map(

--- a/test/piefed-site-counts.test.ts
+++ b/test/piefed-site-counts.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BaseClientOptions } from "../src/BaseClient";
+import ThreadiverseClient, { clearCache } from "../src/ThreadiverseClient";
+
+const BASE_URL = "https://piefed.example.com";
+const NODEINFO_HREF = "https://piefed.example.com/nodeinfo/2.1";
+
+// Mirrors the shape PieFed's GET /api/alpha/site returns for an authenticated
+// request: the logged-in user's post/comment totals live on
+// `my_user.local_user_view.counts`, NOT on the nested `person` object.
+const SITE_RESPONSE = {
+  admins: [],
+  my_user: {
+    community_blocks: [],
+    discussion_languages: [],
+    follows: [],
+    instance_blocks: [],
+    local_user_view: {
+      counts: {
+        comment_count: 42,
+        person_id: 99,
+        post_count: 7,
+      },
+      local_user: {
+        show_nsfw: true,
+      },
+      person: {
+        actor_id: "https://piefed.example.com/u/me",
+        banned: false,
+        bot: false,
+        deleted: false,
+        id: 99,
+        instance_id: 1,
+        local: true,
+        published: "2024-01-01T00:00:00.000000Z",
+        title: "Me",
+        user_name: "me",
+      },
+    },
+    moderates: [],
+    person_blocks: [],
+  },
+  site: {
+    actor_id: "https://piefed.example.com",
+    description: "An example PieFed instance",
+    icon: "https://piefed.example.com/icon.png",
+    name: "Piefed Example",
+    registration_mode: "Open",
+    sidebar: "Sidebar markdown",
+    user_count: 100,
+  },
+  version: "1.6.27",
+};
+
+function setupSiteTest() {
+  const mockFetch = vi.fn(async (url: unknown) => {
+    const urlStr =
+      typeof url === "string"
+        ? url
+        : url instanceof URL
+          ? url.toString()
+          : url && typeof url === "object" && "url" in url
+            ? (url as Request).url
+            : (() => {
+                throw new Error("Unsupported url type in fetch mock");
+              })();
+
+    if (urlStr === `${BASE_URL}/.well-known/nodeinfo`) {
+      return new Response(
+        JSON.stringify({
+          links: [
+            {
+              href: NODEINFO_HREF,
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.1",
+            },
+          ],
+        }),
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      );
+    }
+
+    if (urlStr === NODEINFO_HREF) {
+      return new Response(
+        JSON.stringify({
+          software: { name: "piefed", version: "1.6.27" },
+        }),
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      );
+    }
+
+    if (urlStr.startsWith(`${BASE_URL}/api/alpha/site`)) {
+      return new Response(JSON.stringify(SITE_RESPONSE), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      });
+    }
+
+    throw new Error(`Unexpected fetch call: ${urlStr}`);
+  });
+
+  const options: BaseClientOptions = { fetchFunction: mockFetch, headers: {} };
+  return new ThreadiverseClient(BASE_URL, options);
+}
+
+describe("piefed getSite my_user counts", () => {
+  beforeEach(() => {
+    clearCache();
+  });
+
+  it("surfaces local_user_view counts on the person (own profile)", async () => {
+    const client = setupSiteTest();
+
+    const response = await client.getSite();
+
+    const person = response.my_user!.local_user_view.person;
+    expect(person.comment_count).toBe(42);
+    expect(person.post_count).toBe(7);
+  });
+});


### PR DESCRIPTION
## Problem

Comment and post counts show **0** on a piefed user's **own profile**.

The bug is not in `getPersonDetails` (that path correctly maps `person_view.counts` and was verified against a live instance — `piefed.social` v1.6.27 returns real counts). The breakage is on the logged-in user's own profile, which Voyager renders from `getSite()` via `my_user.local_user_view.person.{post_count, comment_count}`.

PieFed's `GET /api/alpha/site` returns the logged-in user's totals on `my_user.local_user_view.`**`counts`** (a `PersonAggregates`), separate from the nested `person` object — confirmed in the OpenAPI schema and in PieFed's source (`user.post_count` / `user.post_reply_count`).

In `getSite()`, `compat.toPerson(...)` was called **without** those counts, so `toPerson`'s `counts?.comment_count ?? 0` defaulted both to `0`.

## Fix

Pass `local_user_view.counts` through to `toPerson()`:

```ts
person: compat.toPerson(
  response.data!.my_user.local_user_view.person,
  response.data!.my_user.local_user_view.counts, // added
),
```

## Testing

- Reproduced against a real piefed instance (`piefed.social`) and confirmed the response shape via PieFed's source.
- Added `test/piefed-site-counts.test.ts`, an end-to-end `getSite()` test (provider discovery + `SafeClient` validation) using a faithful `/api/alpha/site` fixture. It fails on `main` (`expected +0 to be 42`) and passes with this fix.
- Full suite (8 files / 26 tests), `tsc --noEmit`, and ESLint all pass.