### PR TITLE
Post-merge review fixes for #44

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,12 @@ instance.mock("GET /api/v4/post/list", {
   ]),
 });
 
-// Unit tests: pass instance.fetch as fetchFunction
-const client = new ThreadiverseClient(instance.origin, {
-  fetchFunction: instance.fetch,
-});
+// Unit tests: clientOptions() routes fetch through the fake and keeps
+// software discovery isolated from other tests
+const client = new ThreadiverseClient(
+  instance.origin,
+  instance.clientOptions(),
+);
 
 // Playwright: route all traffic for the fake host
 await instance.install(page);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threadiverse",
-  "version": "0.14.3",
+  "version": "0.15.0",
   "description": "Unified typescript client for threadiverse instances (Lemmy, Piefed, Mbin etc)",
   "license": "AGPL-3.0-only",
   "author": "Alexander Harding <noreply@harding.dev>",

--- a/src/SafeClient.ts
+++ b/src/SafeClient.ts
@@ -1,6 +1,6 @@
 import type { UnsafePiefedClient } from "./providers/piefed";
 
-import { endpoints } from "./endpoints";
+import { installEndpointMethods } from "./endpoints";
 import { UnsafeLemmyV0Client } from "./providers/lemmyv0";
 import { UnsafeLemmyV1Client } from "./providers/lemmyv1";
 
@@ -8,8 +8,6 @@ type AnyClient =
   | typeof UnsafeLemmyV0Client
   | typeof UnsafeLemmyV1Client
   | typeof UnsafePiefedClient;
-
-type AnyMethod = (...params: unknown[]) => Promise<unknown>;
 
 /**
  * Wraps a provider class so that every endpoint's response is validated
@@ -23,18 +21,19 @@ export default function buildSafeClient(_Client: AnyClient): AnyClient {
 
   class SafeClient extends Client {}
 
-  for (const [endpoint, schema] of Object.entries(endpoints)) {
-    (SafeClient.prototype as unknown as Record<string, AnyMethod>)[endpoint] =
-      async function (...params) {
+  installEndpointMethods(
+    SafeClient.prototype,
+    (endpoint, schema) =>
+      async function (this: InstanceType<AnyClient>, ...params) {
         // Resolved at call time (like `super.<endpoint>()` would be)
-        const unsafeMethod = Client.prototype[
-          endpoint as keyof typeof endpoints
-        ] as AnyMethod;
+        const unsafeMethod = Client.prototype[endpoint] as (
+          ...params: unknown[]
+        ) => Promise<unknown>;
 
         const response = await unsafeMethod.apply(this, params);
         return schema ? schema.parse(response) : response;
-      };
-  }
+      },
+  );
 
   return SafeClient;
 }

--- a/src/ThreadiverseClient.ts
+++ b/src/ThreadiverseClient.ts
@@ -1,20 +1,23 @@
 import { satisfies } from "compare-versions";
 
 import { BaseClient, BaseClientOptions, ProviderInfo } from "./BaseClient";
-import { endpoints } from "./endpoints";
+import { installEndpointMethods } from "./endpoints";
 import { UnsupportedSoftwareError } from "./errors";
 import LemmyV0Client from "./providers/lemmyv0";
 import LemmyV1Client from "./providers/lemmyv1";
 import PiefedClient from "./providers/piefed";
-import { Nodeinfo21Payload, resolveSoftware } from "./wellknown";
+import {
+  DiscoveryCache,
+  Nodeinfo21Payload,
+  resolveSoftware,
+} from "./wellknown";
+
+export type { DiscoveryCache } from "./wellknown";
 
 // Default (global) cache for software discovery promises by hostname.
 // Pass `discoveryCache` in options to scope discovery per client instead
 // (e.g. for server-side or test usage).
-const globalDiscoveryCache = new Map<
-  string,
-  ReturnType<typeof resolveSoftware>
->();
+const globalDiscoveryCache: DiscoveryCache = new Map();
 
 export interface ThreadiverseClientOptions extends BaseClientOptions {
   /**
@@ -22,10 +25,8 @@ export interface ThreadiverseClientOptions extends BaseClientOptions {
    * keyed by hostname. Defaults to a cache shared by all clients in the
    * process; pass your own `Map` to scope it (server-side, tests).
    */
-  discoveryCache?: Map<string, Promise<Nodeinfo21Payload["software"]>>;
+  discoveryCache?: DiscoveryCache;
 }
-
-type AnyMethod = (...params: unknown[]) => Promise<unknown>;
 
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging --
  * Endpoint methods are installed onto the prototype from the endpoint table
@@ -43,13 +44,16 @@ class ThreadiverseClient {
     return [LemmyV1Client, LemmyV0Client, PiefedClient] as const;
   }
   static {
-    for (const endpoint of Object.keys(endpoints) as (keyof BaseClient)[]) {
-      (this.prototype as unknown as Record<string, AnyMethod>)[endpoint] =
+    installEndpointMethods(
+      this.prototype,
+      (endpoint) =>
         async function (this: ThreadiverseClient, ...params) {
           const client = await this.ensureClient();
-          return (client[endpoint] as AnyMethod).apply(client, params);
-        };
-    }
+          return (
+            client[endpoint] as (...params: unknown[]) => Promise<unknown>
+          ).apply(client, params);
+        },
+    );
   }
   get software(): ProviderInfo {
     if (
@@ -72,7 +76,7 @@ class ThreadiverseClient {
     | Awaited<ReturnType<typeof resolveSoftware>>
     | undefined;
 
-  private discoveryCache: Map<string, ReturnType<typeof resolveSoftware>>;
+  private discoveryCache: DiscoveryCache;
 
   private hostname: string;
 
@@ -103,14 +107,8 @@ class ThreadiverseClient {
   }
 
   async getSoftware(): Promise<ProviderInfo> {
-    const client = await this.ensureClient();
-
-    if (!this.discoveredSoftware) throw new Error("Internal error");
-
-    return {
-      name: getBaseClientConstructor(client).softwareName,
-      version: this.discoveredSoftware.version,
-    };
+    await this.ensureClient();
+    return this.software;
   }
 
   private async ensureClient(): Promise<BaseClient> {

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -5,15 +5,21 @@ import type { BaseClient } from "./BaseClient";
 import * as schemas from "./schemas";
 
 /**
- * Every endpoint must map to a schema validating the full resolved response
- * (or `null` when the endpoint resolves with no data to validate). The
- * schema's output must be assignable to the return type declared on
- * `BaseClient` — that contract is enforced here at compile time.
+ * Every endpoint must map to a schema validating the full resolved response;
+ * `null` (skip validation) is only permitted — and required — for endpoints
+ * that resolve with `void`. The schema's output must be assignable to the
+ * return type declared on `BaseClient`, and every `BaseClient` member must
+ * be an async method (the install loops wrap everything in `async`) — all
+ * enforced here at compile time.
  */
 type EndpointTable = {
-  [K in keyof BaseClient]: null | z.ZodMiniType<
-    Awaited<ReturnType<BaseClient[K]>>
-  >;
+  [K in keyof BaseClient]: BaseClient[K] extends (
+    ...params: never[]
+  ) => Promise<infer Response>
+    ? [Response] extends [void]
+      ? null
+      : z.ZodMiniType<Response>
+    : never;
 };
 
 const CommentViewResponse = z.object({ comment_view: schemas.CommentView });
@@ -99,3 +105,29 @@ export const endpoints = {
 } satisfies EndpointTable;
 
 export type EndpointName = keyof typeof endpoints;
+
+type AnyMethod = (...params: unknown[]) => Promise<unknown>;
+
+type EndpointSchema = (typeof endpoints)[EndpointName];
+
+/**
+ * Install a method for every endpoint in the table onto a prototype.
+ * `Object.defineProperty` keeps the methods non-enumerable, matching
+ * class-method semantics (so `for...in` over a client stays clean).
+ */
+export function installEndpointMethods(
+  prototype: object,
+  build: (endpoint: EndpointName, schema: EndpointSchema) => AnyMethod,
+): void {
+  for (const [endpoint, schema] of Object.entries(endpoints) as [
+    EndpointName,
+    EndpointSchema,
+  ][]) {
+    Object.defineProperty(prototype, endpoint, {
+      configurable: true,
+      enumerable: false,
+      value: build(endpoint, schema),
+      writable: true,
+    });
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -69,8 +69,8 @@ export class PiefedResponseError extends ResponseError {
 }
 
 export class UnexpectedResponseError extends FediverseError {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, errorOptions?: ErrorOptions) {
+    super(message, errorOptions);
     this.name = "UnexpectedResponseError";
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from "./BaseClient";
 export * from "./errors";
 export * from "./providers";
 export {
+  type DiscoveryCache,
   default as ThreadiverseClient,
   type ThreadiverseClientOptions,
 } from "./ThreadiverseClient";

--- a/src/testing/FakeInstance.ts
+++ b/src/testing/FakeInstance.ts
@@ -86,6 +86,7 @@ interface RouteLike {
 interface Waiter {
   matcher: Matcher;
   predicate: (call: RecordedCall) => boolean;
+  reject: (error: unknown) => void;
   resolve: (call: RecordedCall) => void;
 }
 
@@ -274,6 +275,10 @@ export class FakeInstance {
       const waiter: Waiter = {
         matcher,
         predicate,
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
         resolve: (call) => {
           clearTimeout(timer);
           resolve(call);
@@ -291,10 +296,20 @@ export class FakeInstance {
 
   #notifyWaiters(call: RecordedCall): void {
     for (const waiter of [...this.#waiters]) {
-      if (
-        `${call.method} ${call.pathname}` === waiter.matcher &&
-        waiter.predicate(call)
-      ) {
+      if (`${call.method} ${call.pathname}` !== waiter.matcher) continue;
+
+      let matches: boolean;
+      try {
+        matches = waiter.predicate(call);
+      } catch (error) {
+        // A throwing predicate is the waiter's bug — reject that waiter
+        // instead of failing the unrelated request being handled
+        this.#removeWaiter(waiter);
+        waiter.reject(error);
+        continue;
+      }
+
+      if (matches) {
         this.#removeWaiter(waiter);
         waiter.resolve(call);
       }

--- a/src/testing/FakeInstance.ts
+++ b/src/testing/FakeInstance.ts
@@ -7,15 +7,21 @@
  * adapters for `fetch` (vitest / `fetchFunction`) and Playwright
  * (`page.route`).
  *
- * Software-specific factories (e.g. `createFakeLemmyV1Instance`) construct
- * one of these pre-seeded with that software's wire-format defaults.
+ * Software-specific factories (e.g. `FakeLemmyV1Instance`) construct one of
+ * these pre-seeded with that software's wire-format defaults.
  */
+
+import type { z } from "zod/v4-mini";
+
+import type { ThreadiverseClientOptions } from "../ThreadiverseClient";
+
+import { DiscoveryCache, Nodeinfo21Payload, NodeinfoLink } from "../wellknown";
 
 export interface FakeInstanceOptions {
   /** Bare hostname (no scheme), e.g. `"v1.test.lemmy"` */
   host: string;
   /** Served via nodeinfo discovery, e.g. `{ name: "lemmy", version: "1.0.0-beta.1" }` */
-  software: { name: string; version: string };
+  software: Nodeinfo21Payload["software"];
 }
 
 export type FakeRequest = {
@@ -48,6 +54,9 @@ export type Responder =
   | ((call: RecordedCall) => FakeResponse | Promise<FakeResponse>)
   | FakeResponse;
 
+/** Response statuses that must not carry a body (fetch `Response` throws) */
+const NULL_BODY_STATUSES = [204, 205, 304];
+
 /** Structural subset of Playwright's `Page` */
 interface PageLike {
   // Promise<unknown> because the return type varies by Playwright version
@@ -61,7 +70,11 @@ interface PageLike {
 /** Structural subset of Playwright's `Route`, to avoid a Playwright dependency */
 interface RouteLike {
   abort(errorCode?: string): Promise<void>;
-  fulfill(response: { json?: unknown; status?: number }): Promise<void>;
+  fulfill(response: {
+    body?: string;
+    json?: unknown;
+    status?: number;
+  }): Promise<void>;
   request(): {
     headers(): Record<string, string>;
     method(): string;
@@ -70,24 +83,51 @@ interface RouteLike {
   };
 }
 
+interface Waiter {
+  matcher: Matcher;
+  predicate: (call: RecordedCall) => boolean;
+  resolve: (call: RecordedCall) => void;
+}
+
 export class FakeInstance {
   readonly host: string;
 
   readonly origin: string;
 
-  readonly software: { name: string; version: string };
+  readonly software: Nodeinfo21Payload["software"];
 
   #calls: RecordedCall[] = [];
 
+  #discoveryCache: DiscoveryCache = new Map();
+
   #handlers = new Map<Matcher, Responder>();
+
+  #waiters: Waiter[] = [];
 
   constructor(options: FakeInstanceOptions) {
     this.host = options.host;
     this.origin = `https://${options.host}`;
     this.software = options.software;
+
+    // Discovery is seeded through the ordinary route table, so tests can
+    // override it (e.g. simulate an unreachable or unsupported instance)
+    // and assert on discovery requests like any other call
+    this.mock("GET /.well-known/nodeinfo", {
+      json: {
+        links: [
+          {
+            href: `${this.origin}/nodeinfo/2.1`,
+            rel: "http://nodeinfo.diaspora.software/ns/schema/2.1",
+          } satisfies z.input<typeof NodeinfoLink>,
+        ],
+      },
+    });
+    this.mock("GET /nodeinfo/2.1", {
+      json: { software: this.software, version: "2.1" },
+    });
   }
 
-  /** All recorded API requests matching `"METHOD /path"` (query ignored). */
+  /** All recorded requests matching `"METHOD /path"` (query ignored). */
   calls(matcher: Matcher): RecordedCall[] {
     return this.#calls.filter(
       (call) => `${call.method} ${call.pathname}` === matcher,
@@ -95,8 +135,25 @@ export class FakeInstance {
   }
 
   /**
-   * `fetch`-compatible adapter. Pass as `fetchFunction` to a
-   * `ThreadiverseClient`, or install as a global fetch mock in unit tests.
+   * Options for a `ThreadiverseClient` scoped to this fake: routes fetch
+   * through the instance and isolates software discovery from the
+   * process-global cache (so multiple fakes for the same host — e.g.
+   * different versions across tests — can't contaminate each other).
+   *
+   * ```ts
+   * const client = new ThreadiverseClient(fake.origin, fake.clientOptions());
+   * ```
+   */
+  clientOptions(): ThreadiverseClientOptions {
+    return {
+      discoveryCache: this.#discoveryCache,
+      fetchFunction: this.fetch,
+    };
+  }
+
+  /**
+   * `fetch`-compatible adapter. Prefer `clientOptions()` when constructing a
+   * `ThreadiverseClient`; use this directly to install a global fetch mock.
    * Unrouted requests and `{ abort }` responses throw `TypeError`, like a
    * real network failure.
    */
@@ -119,11 +176,16 @@ export class FakeInstance {
     if ("abort" in result)
       throw new TypeError(`fetch failed: simulated abort (${result.abort})`);
 
-    return Response.json(result.json, { status: result.status ?? 200 });
+    const status = result.status ?? 200;
+
+    if (NULL_BODY_STATUSES.includes(status))
+      return new Response(null, { status });
+
+    return Response.json(result.json, { status });
   };
 
   /**
-   * Resolve a request against discovery routes and the mock table.
+   * Resolve a request against the route table.
    *
    * Returns `undefined` for requests to other origins (callers decide
    * whether to pass those through). Unmocked same-origin requests are
@@ -134,21 +196,6 @@ export class FakeInstance {
 
     if (url.origin !== this.origin) return undefined;
 
-    if (request.method === "GET" && url.pathname === "/.well-known/nodeinfo")
-      return {
-        json: {
-          links: [
-            {
-              href: `${this.origin}/nodeinfo/2.1`,
-              rel: "http://nodeinfo.diaspora.software/ns/schema/2.1",
-            },
-          ],
-        },
-      };
-
-    if (request.method === "GET" && url.pathname === "/nodeinfo/2.1")
-      return { json: { software: this.software, version: "2.1" } };
-
     const call: RecordedCall = {
       body: parseBody(request.body ?? null),
       headers: request.headers ?? {},
@@ -157,6 +204,7 @@ export class FakeInstance {
       query: url.searchParams,
     };
     this.#calls.push(call);
+    this.#notifyWaiters(call);
 
     const responder = this.#handlers.get(
       `${request.method} ${url.pathname}` as Matcher,
@@ -195,7 +243,12 @@ export class FakeInstance {
 
       if ("abort" in result) return route.abort(result.abort);
 
-      return route.fulfill({ json: result.json, status: result.status ?? 200 });
+      const status = result.status ?? 200;
+
+      if (NULL_BODY_STATUSES.includes(status))
+        return route.fulfill({ body: "", status });
+
+      return route.fulfill({ json: result.json, status });
     });
   }
 
@@ -204,23 +257,53 @@ export class FakeInstance {
     this.#handlers.set(matcher, responder);
   }
 
-  /** Wait until a matching request is recorded, then return the latest. */
+  /**
+   * Wait until a matching request is recorded, then return the latest.
+   * Resolution is push-based (no polling), so pending waiters settle the
+   * moment the request lands — only the timeout path needs real timers.
+   */
   async waitForCall(
     matcher: Matcher,
     predicate: (call: RecordedCall) => boolean = () => true,
     { timeoutMs = 5000 } = {},
   ): Promise<RecordedCall> {
-    const deadline = Date.now() + timeoutMs;
+    const existing = this.calls(matcher).filter(predicate).at(-1);
+    if (existing) return existing;
 
-    for (;;) {
-      const match = this.calls(matcher).filter(predicate).at(-1);
-      if (match) return match;
+    return new Promise<RecordedCall>((resolve, reject) => {
+      const waiter: Waiter = {
+        matcher,
+        predicate,
+        resolve: (call) => {
+          clearTimeout(timer);
+          resolve(call);
+        },
+      };
 
-      if (Date.now() > deadline)
-        throw new Error(`Timed out waiting for ${matcher}`);
+      const timer = setTimeout(() => {
+        this.#removeWaiter(waiter);
+        reject(new Error(`Timed out waiting for ${matcher}`));
+      }, timeoutMs);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      this.#waiters.push(waiter);
+    });
+  }
+
+  #notifyWaiters(call: RecordedCall): void {
+    for (const waiter of [...this.#waiters]) {
+      if (
+        `${call.method} ${call.pathname}` === waiter.matcher &&
+        waiter.predicate(call)
+      ) {
+        this.#removeWaiter(waiter);
+        waiter.resolve(call);
+      }
     }
+  }
+
+  #removeWaiter(waiter: Waiter): void {
+    const index = this.#waiters.indexOf(waiter);
+    if (index !== -1) this.#waiters.splice(index, 1);
   }
 }
 

--- a/src/testing/lemmyv1/builders.ts
+++ b/src/testing/lemmyv1/builders.ts
@@ -21,6 +21,8 @@ export interface LemmyV1BuildersOptions {
 export const DEFAULT_NOW = "2026-05-21T12:00:00.000Z";
 export const DEFAULT_VERSION = "1.0.0-beta.1";
 
+const DEFAULT_COMMUNITY_ID = 111;
+
 export type LemmyV1Builders = ReturnType<typeof createLemmyV1Builders>;
 
 export function createLemmyV1Builders({
@@ -35,9 +37,6 @@ export function createLemmyV1Builders({
   }): Wire<LemmyV1.Person> {
     return {
       ap_id: `https://${host}/u/${over.name}`,
-      avatar: undefined,
-      banner: undefined,
-      bio: undefined,
       bot_account: false,
       comment_count: 0,
       deleted: false,
@@ -46,11 +45,9 @@ export function createLemmyV1Builders({
       instance_id: 1,
       last_refreshed_at: now,
       local: true,
-      matrix_user_id: undefined,
       name: over.name,
       post_count: 0,
       published_at: now,
-      updated_at: undefined,
     };
   }
 
@@ -61,11 +58,9 @@ export function createLemmyV1Builders({
 
     return {
       ap_id: `https://${host}/c/${name}`,
-      banner: undefined,
       comments: 0,
       deleted: false,
-      icon: undefined,
-      id: over.id ?? 111,
+      id: over.id ?? DEFAULT_COMMUNITY_ID,
       instance_id: 1,
       last_refreshed_at: now,
       local: true,
@@ -77,13 +72,10 @@ export function createLemmyV1Builders({
       published_at: now,
       removed: false,
       report_count: 0,
-      sidebar: undefined,
       subscribers: 1,
       subscribers_local: 1,
-      summary: undefined,
       title: over.title ?? "Test Community",
       unresolved_report_count: 0,
-      updated_at: undefined,
       users_active_day: 0,
       users_active_half_year: 0,
       users_active_month: 0,
@@ -101,17 +93,13 @@ export function createLemmyV1Builders({
     url?: string;
   }): Wire<LemmyV1.Post> {
     return {
-      alt_text: undefined,
       ap_id: `https://${host}/post/${over.id}`,
       body: over.body,
       comments: 0,
-      community_id: (over.community ?? community()).id,
+      community_id: over.community?.id ?? DEFAULT_COMMUNITY_ID,
       creator_id: over.creator.id,
       deleted: false,
       downvotes: 0,
-      embed_description: undefined,
-      embed_title: undefined,
-      embed_video_url: undefined,
       featured_community: false,
       featured_local: false,
       federation_pending: false,
@@ -126,12 +114,9 @@ export function createLemmyV1Builders({
       removed: false,
       report_count: 0,
       score: 1,
-      thumbnail_url: undefined,
       unresolved_report_count: 0,
-      updated_at: undefined,
       upvotes: 1,
       url: over.url,
-      url_content_type: undefined,
     };
   }
 
@@ -143,21 +128,17 @@ export function createLemmyV1Builders({
     name: string;
     url?: string;
   }): Wire<LemmyV1.PostView> {
+    const resolvedCommunity = over.community ?? community();
+
     return {
       can_mod: false,
-      community: over.community ?? community(),
-      community_actions: undefined,
+      community: resolvedCommunity,
       creator: over.creator,
-      creator_ban_expires_at: undefined,
       creator_banned: false,
       creator_banned_from_community: false,
-      creator_community_ban_expires_at: undefined,
       creator_is_admin: false,
       creator_is_moderator: false,
-      image_details: undefined,
-      person_actions: undefined,
-      post: post(over),
-      post_actions: undefined,
+      post: post({ ...over, community: resolvedCommunity }),
       tags: [],
     };
   }
@@ -195,20 +176,14 @@ export function createLemmyV1Builders({
         report_count: 0,
         score: 1,
         unresolved_report_count: 0,
-        updated_at: undefined,
         upvotes: 1,
       },
-      comment_actions: undefined,
       community: over.post.community,
-      community_actions: undefined,
       creator,
-      creator_ban_expires_at: undefined,
       creator_banned: false,
       creator_banned_from_community: false,
-      creator_community_ban_expires_at: undefined,
       creator_is_admin: false,
       creator_is_moderator: false,
-      person_actions: undefined,
       post: over.post.post,
       tags: [],
     };
@@ -233,7 +208,6 @@ export function createLemmyV1Builders({
         published_at: now,
         recipient_id: over.recipient.id,
         removed: false,
-        updated_at: undefined,
       },
       recipient: over.recipient,
     };
@@ -263,7 +237,6 @@ export function createLemmyV1Builders({
       },
       target_comment: over.target_comment,
       target_community: over.target_community,
-      target_instance: undefined,
       target_person: over.target_person,
       target_post: over.target_post,
     };
@@ -284,8 +257,6 @@ export function createLemmyV1Builders({
       default_items_per_page: 50,
       default_listing_type: "all",
       default_post_sort_type: "active",
-      default_post_time_range_seconds: undefined,
-      email: undefined,
       email_verified: false,
       hide_media: false,
       id: over.person_id,
@@ -324,7 +295,6 @@ export function createLemmyV1Builders({
       instance_persons_blocks: [],
       keyword_blocks: [],
       local_user_view: {
-        ban_expires_at: undefined,
         banned: false,
         local_user: localUser({
           admin: over.admin,
@@ -346,13 +316,10 @@ export function createLemmyV1Builders({
       moderates: [],
       multi_communities_created: [],
       person_view: {
-        ban_expires_at: undefined,
         banned: false,
         is_admin: false,
         person: subject,
-        person_actions: undefined,
       },
-      site: undefined,
     };
   }
 
@@ -364,12 +331,10 @@ export function createLemmyV1Builders({
       community_view: {
         can_mod: false,
         community: over.community ?? community(),
-        community_actions: undefined,
         tags: [],
       },
       discussion_languages: [],
       moderators: [],
-      site: undefined,
     };
   }
 
@@ -385,7 +350,6 @@ export function createLemmyV1Builders({
       blocked_urls: [],
       captcha_enabled: false,
       discussion_languages: [],
-      last_application_duration_seconds: undefined,
       oauth_providers: [],
       site_view: {
         instance: {
@@ -393,12 +357,10 @@ export function createLemmyV1Builders({
           id: 1,
           published_at: now,
           software: "lemmy",
-          updated_at: undefined,
           version,
         },
         local_site: {
           application_email_admins: false,
-          application_question: undefined,
           comment_downvotes: "all",
           comment_upvotes: "all",
           comments: 0,
@@ -409,7 +371,6 @@ export function createLemmyV1Builders({
           default_post_listing_mode: "list",
           default_post_listing_type: "all",
           default_post_sort_type: "active",
-          default_post_time_range_seconds: undefined,
           default_theme: "browser",
           email_notifications_disabled: false,
           email_verification_required: false,
@@ -422,10 +383,8 @@ export function createLemmyV1Builders({
           image_max_thumbnail_size: 256,
           image_max_upload_size: 50_000_000,
           image_mode: "store_link_previews",
-          image_proxy_bypass_domains: undefined,
           image_upload_disabled: false,
           image_upload_timeout_seconds: 30,
-          legal_information: undefined,
           nsfw_content_disallowed: false,
           oauth_registration: false,
           post_downvotes: "all",
@@ -437,9 +396,6 @@ export function createLemmyV1Builders({
           reports_email_admins: false,
           site_id: 1,
           site_setup: true,
-          slur_filter_regex: undefined,
-          suggested_multi_community_id: undefined,
-          updated_at: undefined,
           users: 1,
           users_active_day: 1,
           users_active_half_year: 1,
@@ -463,25 +419,17 @@ export function createLemmyV1Builders({
           register_max_requests: 3,
           search_interval_seconds: 600,
           search_max_requests: 60,
-          updated_at: undefined,
         },
         site: {
           ap_id: `https://${host}/`,
-          banner: undefined,
-          content_warning: undefined,
-          icon: undefined,
           id: 1,
           inbox_url: `https://${host}/site_inbox`,
           instance_id: 1,
           last_refreshed_at: now,
           name: over.name ?? "Test v1 site",
           published_at: now,
-          sidebar: undefined,
-          summary: undefined,
-          updated_at: undefined,
         },
       },
-      tagline: undefined,
       version,
     };
   }

--- a/src/testing/lemmyv1/index.ts
+++ b/src/testing/lemmyv1/index.ts
@@ -1,7 +1,3 @@
-import type * as LemmyV1 from "lemmy-js-client-v1";
-
-import type { Wire } from "../wire";
-
 import { FakeInstance } from "../FakeInstance";
 import {
   createLemmyV1Builders,
@@ -10,27 +6,29 @@ import {
 } from "./builders";
 
 export interface FakeLemmyV1InstanceOptions {
-  /** Seed for `GET /api/v4/comment/list` (default: none) */
-  comments?: Wire<LemmyV1.CommentView>[];
   /** Bare hostname (no scheme) the fake instance answers for */
   host?: string;
-  /** Seed for `GET /api/v4/modlog` (default: none) */
-  modlog?: Wire<LemmyV1.ModlogView>[];
-  /** Seed for `GET /api/v4/post/list` (default: none) */
-  posts?: Wire<LemmyV1.PostView>[];
   /** Lemmy version reported via nodeinfo and `GET /api/v4/site` */
   version?: string;
 }
 
+/**
+ * `FakeInstance` pre-seeded with the Lemmy v1 routes an app touches at
+ * startup, each serving an empty default. Seed data with `mock()` and the
+ * typed builders on `build`:
+ *
+ * ```ts
+ * fake.mock("GET /api/v4/post/list", {
+ *   json: fake.build.pagedResponse([fake.build.postView({ ... })]),
+ * });
+ * ```
+ */
 export class FakeLemmyV1Instance extends FakeInstance {
   /** Wire-format builders bound to this instance's host */
   readonly build: LemmyV1Builders;
 
   constructor({
-    comments = [],
     host = "v1.test.lemmy",
-    modlog = [],
-    posts = [],
     version = DEFAULT_VERSION,
   }: FakeLemmyV1InstanceOptions = {}) {
     super({ host, software: { name: "lemmy", version } });
@@ -38,19 +36,19 @@ export class FakeLemmyV1Instance extends FakeInstance {
     const build = createLemmyV1Builders({ host, version });
     this.build = build;
 
-    // Everything the v1 path touches at app startup
-    this.mock("GET /api/v4/site", {
-      json: build.getSiteResponse({ posts: posts.length }),
-    });
-    this.mock("GET /api/v4/post/list", {
-      json: build.pagedResponse(posts),
-    });
-    this.mock("GET /api/v4/comment/list", {
-      json: build.pagedResponse(comments),
-    });
-    this.mock("GET /api/v4/modlog", {
-      json: build.pagedResponse(modlog),
-    });
+    // Everything the v1 path touches at app startup. Function responders so
+    // each request gets a fresh object (no shared mutable state) and nothing
+    // is built unless actually requested.
+    this.mock("GET /api/v4/site", () => ({ json: build.getSiteResponse() }));
+    this.mock("GET /api/v4/post/list", () => ({
+      json: build.pagedResponse([]),
+    }));
+    this.mock("GET /api/v4/comment/list", () => ({
+      json: build.pagedResponse([]),
+    }));
+    this.mock("GET /api/v4/modlog", () => ({
+      json: build.pagedResponse([]),
+    }));
   }
 }
 

--- a/src/wellknown.ts
+++ b/src/wellknown.ts
@@ -3,21 +3,32 @@ import { z } from "zod/v4-mini";
 import { BaseClientOptions } from "./BaseClient";
 import { UnexpectedResponseError } from "./errors";
 
-const NodeinfoLinksPayload = z.object({
-  links: z.array(
-    z.object({
-      href: z.string(),
-      rel: z.string(),
-    }),
-  ),
+export const NodeinfoLink = z.object({
+  href: z.string(),
+  rel: z.string(),
 });
 
-const Nodeinfo21Payload = z.object({
+// Entries are validated individually in resolveNodeinfoLink so that one
+// malformed vendor link doesn't break discovery for the whole instance
+export const NodeinfoLinksPayload = z.object({
+  links: z.array(z.unknown()),
+});
+
+export const Nodeinfo21Payload = z.object({
   software: z.object({
     name: z.string(),
     version: z.string(),
   }),
 });
+
+/**
+ * Cache of software discovery results, keyed by hostname. See
+ * `ThreadiverseClientOptions.discoveryCache`.
+ */
+export type DiscoveryCache = Map<
+  string,
+  Promise<Nodeinfo21Payload["software"]>
+>;
 
 export type Nodeinfo21Payload = z.infer<typeof Nodeinfo21Payload>;
 
@@ -36,7 +47,11 @@ export async function resolveSoftware(
 
   const response = await fetch(`${url}/.well-known/nodeinfo`, fetchOptions);
 
-  const data = NodeinfoLinksPayload.parse(await response.json());
+  const data = parseDiscoveryPayload(
+    NodeinfoLinksPayload,
+    await response.json(),
+    "nodeinfo links",
+  );
 
   const nodeinfoLink = resolveNodeinfoLink(data);
 
@@ -45,18 +60,49 @@ export async function resolveSoftware(
 
   const nodeinfoResponse = await fetch(nodeinfoLink, fetchOptions);
 
-  const nodeinfoData = Nodeinfo21Payload.parse(await nodeinfoResponse.json());
+  const nodeinfoData = parseDiscoveryPayload(
+    Nodeinfo21Payload,
+    await nodeinfoResponse.json(),
+    "nodeinfo",
+  );
 
   return nodeinfoData.software;
+}
+
+/**
+ * Discovery is the "is this even a supported fediverse instance?" boundary,
+ * so malformed payloads surface as the library's error taxonomy (with the
+ * ZodError as `cause`) instead of leaking raw validation errors.
+ */
+function parseDiscoveryPayload<Schema extends z.ZodMiniType>(
+  schema: Schema,
+  data: unknown,
+  what: string,
+): z.infer<Schema> {
+  const result = schema.safeParse(data);
+
+  if (!result.success)
+    throw new UnexpectedResponseError(`Malformed ${what} response`, {
+      cause: result.error,
+    });
+
+  return result.data as z.infer<Schema>;
 }
 
 // {"links":[{"rel":"http://nodeinfo.diaspora.software/ns/schema/2.1","href":"https://lemmy.zip/nodeinfo/2.1"}]}
 function resolveNodeinfoLink(
   data: z.infer<typeof NodeinfoLinksPayload>,
 ): string | undefined {
-  return data.links.find((link) =>
-    link.rel.match(
-      /^http:\/\/nodeinfo\.diaspora\.software\/ns\/schema\/2\.\d+$/,
-    ),
-  )?.href;
+  for (const rawLink of data.links) {
+    const link = NodeinfoLink.safeParse(rawLink);
+
+    if (!link.success) continue;
+
+    if (
+      link.data.rel.match(
+        /^http:\/\/nodeinfo\.diaspora\.software\/ns\/schema\/2\.\d+$/,
+      )
+    )
+      return link.data.href;
+  }
 }

--- a/test/ThreadiverseClient.caching.test.ts
+++ b/test/ThreadiverseClient.caching.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BaseClientOptions } from "../src/BaseClient";
-import { clearCache } from "../src/ThreadiverseClient";
+import { FakeInstance } from "../src/testing";
+import { clearCache, DiscoveryCache } from "../src/ThreadiverseClient";
 import ThreadiverseClient from "../src/ThreadiverseClient";
 
 describe("ThreadiverseClient - Caching", () => {
@@ -129,37 +130,17 @@ describe("ThreadiverseClient - Caching", () => {
   });
 
   it("scopes discovery to a provided discoveryCache instead of the global one", async () => {
-    const HOST = "https://lemmy-scoped-cache.example.com";
-
-    const mockFetch = vi.fn(async (url: unknown) => {
-      const urlStr = typeof url === "string" ? url : (url as Request).url;
-
-      if (urlStr === `${HOST}/.well-known/nodeinfo`)
-        return Response.json({
-          links: [
-            {
-              href: `${HOST}/nodeinfo/2.1`,
-              rel: "http://nodeinfo.diaspora.software/ns/schema/2.1",
-            },
-          ],
-        });
-      if (urlStr === `${HOST}/nodeinfo/2.1`)
-        return Response.json({
-          software: { name: "lemmy", version: "0.19.6" },
-        });
-      if (urlStr.startsWith(`${HOST}/api/v3/post/list`))
-        return Response.json({ posts: [] });
-      throw new Error(`Unexpected fetch call: ${urlStr}`);
+    const instance = new FakeInstance({
+      host: "lemmy-scoped-cache.example.com",
+      software: { name: "lemmy", version: "0.19.6" },
     });
+    instance.mock("GET /api/v3/post/list", { json: { posts: [] } });
 
-    const discoveryCache = new Map<
-      string,
-      Promise<{ name: string; version: string }>
-    >();
+    const discoveryCache: DiscoveryCache = new Map();
 
-    const client1 = new ThreadiverseClient(HOST, {
+    const client1 = new ThreadiverseClient(instance.origin, {
       discoveryCache,
-      fetchFunction: mockFetch,
+      fetchFunction: instance.fetch,
     });
     await client1.getPosts({});
 
@@ -167,17 +148,12 @@ describe("ThreadiverseClient - Caching", () => {
 
     // A second client with its own fresh cache must re-discover (proving the
     // global cache was not consulted or populated)
-    const client2 = new ThreadiverseClient(HOST, {
+    const client2 = new ThreadiverseClient(instance.origin, {
       discoveryCache: new Map(),
-      fetchFunction: mockFetch,
+      fetchFunction: instance.fetch,
     });
     await client2.getPosts({});
 
-    const discoveryCalls = mockFetch.mock.calls.filter((call) =>
-      String(
-        typeof call[0] === "string" ? call[0] : (call[0] as Request).url,
-      ).endsWith("/.well-known/nodeinfo"),
-    );
-    expect(discoveryCalls).toHaveLength(2);
+    expect(instance.calls("GET /.well-known/nodeinfo")).toHaveLength(2);
   });
 });

--- a/test/testing-fake-instance.test.ts
+++ b/test/testing-fake-instance.test.ts
@@ -193,4 +193,16 @@ describe("FakeLemmyV1Instance + ThreadiverseClient round trip", () => {
     const call = await pendingCall;
     expect(call.query.get("limit")).toBe("5");
   });
+
+  it("rejects waitForCall (not the request) when a predicate throws", async () => {
+    const { client, instance } = setup();
+
+    const pending = instance.waitForCall("GET /api/v4/post/list", () => {
+      throw new Error("bad predicate");
+    });
+
+    // The request under test must be unaffected by the waiter's bug
+    await expect(client.getPosts({})).resolves.toBeTruthy();
+    await expect(pending).rejects.toThrow("bad predicate");
+  });
 });

--- a/test/testing-fake-instance.test.ts
+++ b/test/testing-fake-instance.test.ts
@@ -31,10 +31,10 @@ function setup() {
     ]),
   });
 
-  const client = new ThreadiverseClient(instance.origin, {
-    discoveryCache: new Map(),
-    fetchFunction: instance.fetch,
-  });
+  const client = new ThreadiverseClient(
+    instance.origin,
+    instance.clientOptions(),
+  );
 
   return { alex, client, instance, posts };
 }
@@ -139,5 +139,58 @@ describe("FakeLemmyV1Instance + ThreadiverseClient round trip", () => {
     instance.mock("GET /api/v4/post/list", { abort: "failed" });
 
     await expect(client.getPosts({})).rejects.toThrow(TypeError);
+  });
+
+  it("records and allows overriding discovery routes", async () => {
+    const { client, instance } = setup();
+
+    instance.mock("GET /.well-known/nodeinfo", { abort: "failed" });
+
+    await expect(client.getPosts({})).rejects.toThrow(TypeError);
+    expect(instance.calls("GET /.well-known/nodeinfo")).toHaveLength(1);
+  });
+
+  it("isolates same-host instances via clientOptions()", async () => {
+    const first = new FakeLemmyV1Instance();
+    const second = new FakeLemmyV1Instance({ version: "1.2.0" });
+
+    const firstClient = new ThreadiverseClient(
+      first.origin,
+      first.clientOptions(),
+    );
+    const secondClient = new ThreadiverseClient(
+      second.origin,
+      second.clientOptions(),
+    );
+
+    expect((await firstClient.getSoftware()).version).toBe("1.0.0-beta.1");
+    expect((await secondClient.getSoftware()).version).toBe("1.2.0");
+  });
+
+  it("serves null-body statuses through the fetch adapter", async () => {
+    const { instance } = setup();
+
+    instance.mock("POST /api/v4/post/mark_as_read", {
+      json: null,
+      status: 204,
+    });
+
+    const response = await instance.fetch(
+      `${instance.origin}/api/v4/post/mark_as_read`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.body).toBeNull();
+  });
+
+  it("waitForCall resolves for an in-flight request without polling", async () => {
+    const { client, instance } = setup();
+
+    const pendingCall = instance.waitForCall("GET /api/v4/post/list");
+    await client.getPosts({ limit: 5 });
+
+    const call = await pendingCall;
+    expect(call.query.get("limit")).toBe("5");
   });
 });


### PR DESCRIPTION
## Summary

Adversarial multi-agent review of the merged #44 (7 finder angles → 22 candidates → per-candidate verification, several empirically reproduced). 10 findings survived (8 confirmed / 2 plausible), 3 refuted with proof. This PR fixes all 10 plus the confirmed cleanup items.

### Correctness fixes

1. **`FakeInstance` discovery routes shadowed the route table** — `mock("GET /.well-known/nodeinfo", …)` was a silent no-op and discovery requests were never recorded. Discovery is now seeded through the ordinary route table: overridable and recorded.
2. **fetch adapter crashed on 204/205/304** — `Response.json(…, { status: 204 })` throws; null-body statuses now return a body-less `Response` (Playwright adapter matched).
3. **Global discovery-cache contamination** (empirically reproduced: two same-host fakes, second client got the first's cached version) — new `fake.clientOptions()` bundles `fetchFunction` + a per-instance `discoveryCache`; README updated.
4. **`waitForCall` polled every 50 ms** — hung forever under `vi.useFakeTimers()`; now push-based (waiters resolve the moment `handle()` records a match).
5. **Endpoint table `null` escape hatch** — a data-returning endpoint could be given `null` and skip validation (and the conformance suite would then codify that). `EndpointTable` now only permits `null` for `Promise<void>` endpoints, and rejects non-async members (a sync method would have been silently wrapped into a Promise).
6. **Discovery threw raw `ZodError`** — malformed nodeinfo now throws `UnexpectedResponseError` with the `ZodError` as `cause`, and one malformed vendor link no longer fails discovery for the whole instance (per-entry validation).
7. **Endpoint methods were enumerable** — shared `installEndpointMethods()` (also de-duplicating the two install loops) uses `defineProperty`, restoring class-method `for...in` semantics.

### Refuted (no action, for the record)

- wellknown error-message change: nothing in Voyager matches the old message/class (only `UnsupportedSoftwareError` is discriminated).
- `federated_instances: null` rejection: all three providers normalize before the schema (latent constraint only).
- void-endpoint passthrough: 13 of 15 already returned the raw provider response pre-refactor; the remaining two are unchanged for every provider.

### Cleanup

`getSoftware()` delegates to the `software` getter; single exported `DiscoveryCache` alias; `FakeLemmyV1Instance` drops its redundant constructor-seed path (hidden `site.posts` count coupling, zero consumers) in favor of `mock()` + lazy per-request defaults; builders lose 56 `field: undefined` filler lines and a throwaway default-community allocation; the scoped-cache test now uses `FakeInstance` instead of a fourth bespoke nodeinfo mock.

### Deferred (noted for later)

Porting `lemmyv1-vote-payload`/`lemmyv1-compat` tests onto the typed builders; an exported route map for `/api/v4` literals (revisit when PieFed/v0 fakes exist).

## Verification

- threadiverse: lint, typecheck, **335/335 tests** (5 new regression tests covering findings 1-4), build
- Voyager (local install, then restored): typecheck, 238 unit tests, lemmyv1 smoke e2e on chromium