### PR TITLE
Scheduled live-smoke suite against real instances

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,0 +1,24 @@
+name: live-smoke
+
+# Read-only smoke tests against live instances (see test/live-smoke.test.ts).
+# Catches upstream API drift on a schedule instead of in consumer bug reports.
+
+on:
+  schedule:
+    - cron: "0 12 * * 1" # Mondays 12:00 UTC
+  workflow_dispatch:
+
+jobs:
+  live-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm i -fg corepack && corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+      - run: pnpm install
+      - run: pnpm vitest run test/live-smoke.test.ts
+        env:
+          LIVE_SMOKE: "1"

--- a/test/live-smoke.test.ts
+++ b/test/live-smoke.test.ts
@@ -15,7 +15,16 @@ const INSTANCES = [
   // TODO: add a Lemmy v1 instance once a stable public one exists
 ] as const;
 
-const OPTIONS = { timeout: 30_000 };
+const OPTIONS = { retry: 2, timeout: 30_000 };
+
+// If the workflow and this gate ever drift apart (e.g. the env var is
+// renamed in one place), the scheduled run would stay green forever while
+// testing nothing. Fail loudly instead.
+it.runIf(
+  process.env.GITHUB_WORKFLOW === "live-smoke" && !process.env.LIVE_SMOKE,
+)("live-smoke workflow must set LIVE_SMOKE", () => {
+  expect.unreachable("live-smoke gate misconfigured");
+});
 
 describe.runIf(process.env.LIVE_SMOKE)("live smoke", () => {
   describe.each(INSTANCES)("$url", ({ software, url }) => {
@@ -55,7 +64,7 @@ describe.runIf(process.env.LIVE_SMOKE)("live smoke", () => {
         type_: "communities",
       });
 
-      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeGreaterThan(0);
     });
   });
 });

--- a/test/live-smoke.test.ts
+++ b/test/live-smoke.test.ts
@@ -1,0 +1,61 @@
+// Read-only drift detection against live instances: if upstream software
+// changes its wire format, this fails in the scheduled live-smoke workflow
+// before consumers hit it in production. Gated so normal test runs stay
+// offline — run manually with:
+//
+//   LIVE_SMOKE=1 pnpm vitest run test/live-smoke.test.ts
+
+import { describe, expect, it } from "vitest";
+
+import ThreadiverseClient from "../src/ThreadiverseClient";
+
+const INSTANCES = [
+  { software: "lemmy", url: "https://lemmy.world" },
+  { software: "piefed", url: "https://piefed.social" },
+  // TODO: add a Lemmy v1 instance once a stable public one exists
+] as const;
+
+const OPTIONS = { timeout: 30_000 };
+
+describe.runIf(process.env.LIVE_SMOKE)("live smoke", () => {
+  describe.each(INSTANCES)("$url", ({ software, url }) => {
+    const client = new ThreadiverseClient(url, {
+      discoveryCache: new Map(),
+    });
+
+    it("discovers software", OPTIONS, async () => {
+      expect((await client.getSoftware()).name).toBe(software);
+    });
+
+    it("getSite passes canonical validation", OPTIONS, async () => {
+      const site = await client.getSite();
+
+      expect(site.site_view.site.name).toBeTruthy();
+    });
+
+    it("getPosts passes canonical validation", OPTIONS, async () => {
+      const { data } = await client.getPosts({ limit: 3, type_: "local" });
+
+      expect(data.length).toBeGreaterThan(0);
+    });
+
+    it("getComments passes canonical validation", OPTIONS, async () => {
+      const { data } = await client.getComments({
+        limit: 3,
+        type_: "local",
+      });
+
+      expect(data.length).toBeGreaterThan(0);
+    });
+
+    it("search passes canonical validation", OPTIONS, async () => {
+      const { data } = await client.search({
+        limit: 3,
+        search_term: "news",
+        type_: "communities",
+      });
+
+      expect(Array.isArray(data)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Weekly read-only smoke tests (`test/live-smoke.test.ts`) against lemmy.world and piefed.social: software discovery, `getSite`, `getPosts`, `getComments`, `search` — each response validated through the canonical Zod pipeline, so upstream wire drift fails here before consumers see it.

- Gated behind `LIVE_SMOKE`; `pnpm test` stays fully offline (suite reports as skipped)
- `.github/workflows/live-smoke.yml`: Mondays 12:00 UTC + manual `workflow_dispatch`
- Verified live: 10/10 passing against both instances just now
- TODO note in the instance list for adding a Lemmy v1 host once a stable public one exists

Independent of #46 (no shared files).