### PR TITLE
feat(testing): typed notification builders

### DIFF
--- a/src/testing/lemmyv1/builders.ts
+++ b/src/testing/lemmyv1/builders.ts
@@ -213,6 +213,57 @@ export function createLemmyV1Builders({
     };
   }
 
+  /**
+   * NotificationView for a comment-based notification (reply/mention/
+   * subscribed). Inapplicable `*_id` fields are JSON `null` on the real
+   * wire (not omitted) — kept here to exercise that normalization.
+   */
+  function commentNotification(over: {
+    comment: Wire<LemmyV1.CommentView>;
+    id: number;
+    kind: "mention" | "reply" | "subscribed";
+    read?: boolean;
+    recipient_id: number;
+  }): Wire<LemmyV1.NotificationView> {
+    return {
+      data: { type_: "comment", ...over.comment },
+      notification: {
+        comment_id: over.comment.comment.id,
+        creator_id: over.comment.creator.id,
+        id: over.id,
+        kind: over.kind,
+        modlog_id: null,
+        post_id: over.comment.post.id,
+        private_message_id: null,
+        published_at: over.comment.comment.published_at,
+        read: over.read ?? false,
+        recipient_id: over.recipient_id,
+      },
+    };
+  }
+
+  function privateMessageNotification(over: {
+    id: number;
+    message: Wire<LemmyV1.PrivateMessageView>;
+    read?: boolean;
+  }): Wire<LemmyV1.NotificationView> {
+    return {
+      data: { type_: "private_message", ...over.message },
+      notification: {
+        comment_id: null,
+        creator_id: over.message.creator.id,
+        id: over.id,
+        kind: "private_message",
+        modlog_id: null,
+        post_id: null,
+        private_message_id: over.message.private_message.id,
+        published_at: over.message.private_message.published_at,
+        read: over.read ?? false,
+        recipient_id: over.message.recipient.id,
+      },
+    };
+  }
+
   function modlogView(over: {
     id: number;
     kind: LemmyV1.ModlogKind;
@@ -442,6 +493,7 @@ export function createLemmyV1Builders({
   }
 
   return {
+    commentNotification,
     commentView,
     community,
     communityResponse,
@@ -454,6 +506,7 @@ export function createLemmyV1Builders({
     personResponse,
     post,
     postView,
+    privateMessageNotification,
     privateMessageView,
   };
 }

--- a/test/testing-fake-instance.test.ts
+++ b/test/testing-fake-instance.test.ts
@@ -99,6 +99,44 @@ describe("FakeLemmyV1Instance + ThreadiverseClient round trip", () => {
     expect(person_view.person.name).toBe("alex");
   });
 
+  it("getNotifications passes canonical validation (incl. null id fields)", async () => {
+    const { alex, client, instance, posts } = setup();
+
+    const other = instance.build.person({ id: 200, name: "other" });
+
+    instance.mock("GET /api/v4/account/notification/list", {
+      json: instance.build.pagedResponse([
+        instance.build.commentNotification({
+          comment: instance.build.commentView({
+            content: "someone replied",
+            creator: other,
+            id: 31,
+            post: posts[0]!,
+          }),
+          id: 301,
+          kind: "reply",
+          recipient_id: alex.id,
+        }),
+        instance.build.privateMessageNotification({
+          id: 303,
+          message: instance.build.privateMessageView({
+            content: "psst",
+            creator: other,
+            id: 41,
+            recipient: alex,
+          }),
+        }),
+      ]),
+    });
+
+    const { data } = await client.getNotifications({});
+
+    expect(data.map((view) => view.notification.kind)).toEqual([
+      "reply",
+      "private_message",
+    ]);
+  });
+
   it("records calls with query for assertions", async () => {
     const { client, instance } = setup();
 


### PR DESCRIPTION
Adds `commentNotification` / `privateMessageNotification` to the lemmy v1 builders — typed against lemmy-js-client-v1, wire-accurate JSON `null` for inapplicable `*_id` fields, plus a round-trip test through `getNotifications` (exercising the compat layer's null normalization that previously broke real notifications). This is the last piece Voyager's e2e fixtures still hand-write; its adoption PR can now be pure test data.