### PR TITLE
feat: canonical error codes (ResponseErrorCode + isErrorCode)

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,16 @@
+import type { LemmyErrorType } from "lemmy-js-client-v0";
+
 import { PiefedErrorResponse } from "./types";
+
+/**
+ * Machine-readable error codes a fediverse server may return (e.g.
+ * "incorrect_login", "too_many_requests"), exposed on `ResponseError.code`.
+ *
+ * The known union gives autocomplete/exhaustiveness for the codes Lemmy
+ * emits; software may emit codes outside it (PieFed, future Lemmy versions),
+ * so any string is accepted. Match with `isErrorCode`.
+ */
+export type ResponseErrorCode = LemmyErrorType["error"] | (string & {});
 
 export class FediverseError extends Error {
   constructor(message: string, errorOptions?: ErrorOptions) {
@@ -28,7 +40,7 @@ export class InvalidPayloadError extends FediverseError {
  * error (e.g. lemmy-js-client's `LemmyError`) is attached as `.cause`.
  */
 export class ResponseError extends FediverseError {
-  code: string;
+  code: ResponseErrorCode;
   status?: number;
 
   constructor(code: string, options?: { cause?: unknown; status?: number }) {
@@ -87,4 +99,17 @@ export class UnsupportedSoftwareError extends UnsupportedError {
     super(message);
     this.name = "UnsupportedSoftwareError";
   }
+}
+
+/**
+ * Whether `error` is a server error response carrying the given
+ * machine-readable code.
+ *
+ * Also matches on `.message` for non-`ResponseError` errors, preserving
+ * legacy `error.message === "code"` semantics.
+ */
+export function isErrorCode(error: unknown, code: ResponseErrorCode): boolean {
+  if (error instanceof ResponseError) return error.code === code;
+  if (error instanceof Error) return error.message === code;
+  return false;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -127,5 +127,9 @@ export type * from "./Search";
 export type * from "./SearchSortType";
 export type * from "./SearchType";
 
-// TODO: unified error handling in threadiverse project
+/**
+ * @deprecated Leaks lemmy-js-client-v0's type into the public API; use
+ * `ResponseErrorCode` (+ `isErrorCode`) from the package root instead.
+ * Will be removed in a future release.
+ */
 export type { LemmyErrorType } from "lemmy-js-client-v0";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,15 @@ export type Instance = z.infer<typeof schemas.Instance>;
 export type InstanceWithFederationState = z.infer<
   typeof schemas.InstanceWithFederationState
 >;
+/**
+ * @deprecated Leaks lemmy-js-client-v0's type into the public API; use
+ * `ResponseErrorCode` (+ `isErrorCode`) from the package root instead.
+ * Will be removed in a future release.
+ *
+ * (Declared as an alias rather than a re-export so the deprecation JSDoc
+ * survives dts bundling.)
+ */
+export type LemmyErrorType = import("lemmy-js-client-v0").LemmyErrorType;
 export type LinkMetadata = z.infer<typeof schemas.LinkMetadata>;
 export type ListCommentReportsResponse = z.infer<
   typeof schemas.ListCommentReportsResponse
@@ -126,10 +135,3 @@ export type * from "./Register";
 export type * from "./Search";
 export type * from "./SearchSortType";
 export type * from "./SearchType";
-
-/**
- * @deprecated Leaks lemmy-js-client-v0's type into the public API; use
- * `ResponseErrorCode` (+ `isErrorCode`) from the package root instead.
- * Will be removed in a future release.
- */
-export type { LemmyErrorType } from "lemmy-js-client-v0";

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isErrorCode,
+  LemmyResponseError,
+  ResponseError,
+  UnsupportedError,
+} from "../src/errors";
+
+describe("isErrorCode", () => {
+  it("matches ResponseError by code", () => {
+    const error = new ResponseError("incorrect_login", { status: 401 });
+
+    expect(isErrorCode(error, "incorrect_login")).toBe(true);
+    expect(isErrorCode(error, "too_many_requests")).toBe(false);
+  });
+
+  it("matches subclasses by code", () => {
+    expect(
+      isErrorCode(
+        new LemmyResponseError("rate_limit_error"),
+        "rate_limit_error",
+      ),
+    ).toBe(true);
+  });
+
+  it("falls back to message matching for plain errors", () => {
+    // Legacy semantics: some code paths throw plain Errors whose message is
+    // the code
+    expect(isErrorCode(new Error("not_found"), "not_found")).toBe(true);
+    expect(isErrorCode(new UnsupportedError("not_found"), "not_found")).toBe(
+      true,
+    );
+  });
+
+  it("rejects non-errors", () => {
+    expect(isErrorCode("incorrect_login", "incorrect_login")).toBe(false);
+    expect(isErrorCode(undefined, "incorrect_login")).toBe(false);
+  });
+});


### PR DESCRIPTION
Replaces the deprecated `LemmyErrorType` re-export (an upstream type leak) with a threadiverse-owned `ResponseErrorCode` union — known Lemmy codes for autocomplete, open to any string for PieFed/future codes — plus an `isErrorCode(error, code)` helper that owns the matching semantics (`.code` on `ResponseError`, legacy `.message` fallback otherwise). Voyager's `helpers/lemmyErrors.ts` can drop its upstream-typed import and use these directly.