### PR TITLE
feat: connect() + sync mode/software introspection

### DIFF
--- a/src/ThreadiverseClient.ts
+++ b/src/ThreadiverseClient.ts
@@ -1,6 +1,11 @@
 import { satisfies } from "compare-versions";
 
-import { BaseClient, BaseClientOptions, ProviderInfo } from "./BaseClient";
+import {
+  BaseClient,
+  BaseClientOptions,
+  ProviderInfo,
+  ThreadiverseMode,
+} from "./BaseClient";
 import { installEndpointMethods } from "./endpoints";
 import { UnsupportedSoftwareError } from "./errors";
 import LemmyV0Client from "./providers/lemmyv0";
@@ -18,6 +23,13 @@ export type { DiscoveryCache } from "./wellknown";
 // Pass `discoveryCache` in options to scope discovery per client instead
 // (e.g. for server-side or test usage).
 const globalDiscoveryCache: DiscoveryCache = new Map();
+
+export interface ClientConnection {
+  /** Which compat mode the client selected, e.g. `"lemmyv1"` */
+  mode: ThreadiverseMode;
+  /** The instance's software as reported by nodeinfo */
+  software: ProviderInfo;
+}
 
 export interface ThreadiverseClientOptions extends BaseClientOptions {
   /**
@@ -55,15 +67,27 @@ class ThreadiverseClient {
         },
     );
   }
+  /**
+   * Which compat mode the client selected. Sync — requires an established
+   * connection (`await connect()`, or any resolved API call).
+   */
+  get mode(): ThreadiverseMode {
+    if (!this.delegateClient)
+      throw new Error("Client not initialized. Await connect() first");
+
+    return getBaseClientConstructor(this.delegateClient).mode;
+  }
+  /**
+   * The instance's software as reported by nodeinfo. Sync — requires an
+   * established connection (`await connect()`, or any resolved API call).
+   */
   get software(): ProviderInfo {
     if (
       !this.delegateClient ||
       !getBaseClientConstructor(this.delegateClient).softwareName ||
       !this.discoveredSoftware
     )
-      throw new Error(
-        "Client not initialized. Wait for getSoftware() or any other async method to resolve first",
-      );
+      throw new Error("Client not initialized. Await connect() first");
 
     return {
       name: getBaseClientConstructor(this.delegateClient).softwareName,
@@ -101,14 +125,26 @@ class ThreadiverseClient {
     }
   }
 
-  async getMode() {
-    const client = await this.ensureClient();
-    return getBaseClientConstructor(client).mode;
+  /**
+   * Resolve the instance's software (cached nodeinfo discovery) and prepare
+   * the underlying provider. Idempotent; after it resolves, the sync `mode`
+   * and `software` getters work. Any API call connects implicitly — use
+   * this when you need introspection before (or without) making requests.
+   */
+  async connect(): Promise<ClientConnection> {
+    await this.ensureClient();
+
+    return { mode: this.mode, software: this.software };
   }
 
+  /** @deprecated Use `connect()` (or the sync `mode` getter once connected) */
+  async getMode(): Promise<ThreadiverseMode> {
+    return (await this.connect()).mode;
+  }
+
+  /** @deprecated Use `connect()` (or the sync `software` getter once connected) */
   async getSoftware(): Promise<ProviderInfo> {
-    await this.ensureClient();
-    return this.software;
+    return (await this.connect()).software;
   }
 
   private async ensureClient(): Promise<BaseClient> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from "./BaseClient";
 export * from "./errors";
 export * from "./providers";
 export {
+  type ClientConnection,
   type DiscoveryCache,
   default as ThreadiverseClient,
   type ThreadiverseClientOptions,

--- a/test/ThreadiverseClient.basic.test.ts
+++ b/test/ThreadiverseClient.basic.test.ts
@@ -28,16 +28,14 @@ describe("ThreadiverseClient - Basic", () => {
       // Accessing the name getter should throw before initialization
       const name = client.software;
       return name;
-    }).toThrow(
-      "Client not initialized. Wait for getSoftware() or any other async method to resolve first",
-    );
+    }).toThrow("Client not initialized. Await connect() first");
   });
 
   it("should throw error when software getter is called before initialization", async () => {
     const client = new ThreadiverseClient("example.com", mockOptions);
 
     expect(() => client.software).toThrow(
-      "Client not initialized. Wait for getSoftware() or any other async method to resolve first",
+      "Client not initialized. Await connect() first",
     );
   });
 });

--- a/test/ThreadiverseClient.connect.test.ts
+++ b/test/ThreadiverseClient.connect.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { FakeLemmyV1Instance } from "../src/testing";
+import ThreadiverseClient from "../src/ThreadiverseClient";
+
+describe("connect() and sync introspection", () => {
+  it("resolves mode + software and enables the sync getters", async () => {
+    const fake = new FakeLemmyV1Instance();
+    const client = new ThreadiverseClient(fake.origin, fake.clientOptions());
+
+    // Not connected yet — sync access must throw loudly
+    expect(() => client.mode).toThrow("connect()");
+    expect(() => client.software).toThrow("connect()");
+
+    expect(await client.connect()).toEqual({
+      mode: "lemmyv1",
+      software: { name: "lemmy", version: "1.0.0-beta.1" },
+    });
+
+    expect(client.mode).toBe("lemmyv1");
+    expect(client.software).toEqual({
+      name: "lemmy",
+      version: "1.0.0-beta.1",
+    });
+  });
+
+  it("is idempotent and does not re-discover", async () => {
+    const fake = new FakeLemmyV1Instance();
+    const client = new ThreadiverseClient(fake.origin, fake.clientOptions());
+
+    await client.connect();
+    await client.connect();
+
+    expect(fake.calls("GET /.well-known/nodeinfo")).toHaveLength(1);
+  });
+
+  it("any API call connects implicitly", async () => {
+    const fake = new FakeLemmyV1Instance();
+    const client = new ThreadiverseClient(fake.origin, fake.clientOptions());
+
+    await client.getPosts({});
+
+    expect(client.mode).toBe("lemmyv1");
+  });
+});


### PR DESCRIPTION
Adds `await client.connect()` → `{ mode, software }` (idempotent; any API call still connects implicitly) and a sync `mode` getter beside the existing `software` getter. `getMode()`/`getSoftware()` become deprecated shims. Consumers get one obvious introspection path — e.g. Voyager's five `await client.getMode()` sort-helper call sites — instead of three overlapping ones.