### PR TITLE
feat(testing): FakePiefedInstance + typed PieFed wire builders

### DIFF
--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,3 +1,4 @@
 export * from "./FakeInstance";
 export * from "./lemmyv1";
+export * from "./piefed";
 export type * from "./wire";

--- a/src/testing/piefed/builders.ts
+++ b/src/testing/piefed/builders.ts
@@ -1,0 +1,275 @@
+// Typed wire-format builders for a fake PieFed instance.
+//
+// Every builder's return type is checked against the same OpenAPI-generated
+// types (src/providers/piefed/schema.ts) the piefed compat layer consumes,
+// so fixtures cannot silently drift from the wire format: regenerating the
+// schema from live swagger turns drift into compile errors here instead of
+// mysteriously failing consumer e2e suites.
+
+import type { components } from "../../providers/piefed/schema";
+import type { Wire } from "../wire";
+
+export interface PiefedBuildersOptions {
+  /** Bare hostname used in generated actor ids, e.g. `"piefed.test"` */
+  host: string;
+  /** Timestamp used for all published dates */
+  now?: string;
+  /** Reported by `GET /api/alpha/site` and nodeinfo */
+  version?: string;
+}
+
+type Schemas = components["schemas"];
+
+export const DEFAULT_PIEFED_VERSION = "1.2.0";
+
+const DEFAULT_COMMUNITY_ID = 111;
+
+export type PiefedBuilders = ReturnType<typeof createPiefedBuilders>;
+
+export function createPiefedBuilders({
+  host,
+  now = "2026-05-21T12:00:00.000Z",
+  version = DEFAULT_PIEFED_VERSION,
+}: PiefedBuildersOptions) {
+  function person(over: {
+    id: number;
+    title?: string;
+    user_name: string;
+  }): Wire<Schemas["Person"]> {
+    return {
+      actor_id: `https://${host}/u/${over.user_name}`,
+      banned: false,
+      bot: false,
+      deleted: false,
+      id: over.id,
+      instance_id: 1,
+      local: true,
+      published: now,
+      title: over.title,
+      user_name: over.user_name,
+    };
+  }
+
+  function community(
+    over: { id?: number; name?: string; title?: string } = {},
+  ): Wire<Schemas["Community"]> {
+    const name = over.name ?? "test_comm";
+
+    return {
+      actor_id: `https://${host}/c/${name}`,
+      ai_generated: false,
+      deleted: false,
+      hidden: false,
+      id: over.id ?? DEFAULT_COMMUNITY_ID,
+      instance_id: 1,
+      local: true,
+      name,
+      nsfw: false,
+      published: now,
+      removed: false,
+      restricted_to_mods: false,
+      title: over.title ?? "Test Community",
+    };
+  }
+
+  function communityView(
+    over: { community?: Wire<Schemas["Community"]> } = {},
+  ): Wire<Schemas["CommunityView"]> {
+    const resolvedCommunity = over.community ?? community();
+
+    return {
+      activity_alert: false,
+      blocked: false,
+      community: resolvedCommunity,
+      counts: {
+        id: resolvedCommunity.id,
+        post_count: 1,
+        post_reply_count: 0,
+        published: now,
+        subscriptions_count: 1,
+        total_subscriptions_count: 1,
+      },
+      subscribed: "NotSubscribed",
+    };
+  }
+
+  function post(over: {
+    body?: string;
+    community?: Wire<Schemas["Community"]>;
+    creator: Wire<Schemas["Person"]>;
+    id: number;
+    title: string;
+    url?: string;
+  }): Wire<Schemas["Post"]> {
+    return {
+      ai_generated: false,
+      ap_id: `https://${host}/post/${over.id}`,
+      body: over.body,
+      community_id: over.community?.id ?? DEFAULT_COMMUNITY_ID,
+      deleted: false,
+      id: over.id,
+      instance_sticky: false,
+      language_id: 0,
+      local: true,
+      locked: false,
+      nsfw: false,
+      post_type: over.url ? "Link" : "Discussion",
+      published: now,
+      removed: false,
+      sticky: false,
+      title: over.title,
+      url: over.url,
+      user_id: over.creator.id,
+    };
+  }
+
+  function postView(over: {
+    body?: string;
+    community?: Wire<Schemas["Community"]>;
+    creator: Wire<Schemas["Person"]>;
+    id: number;
+    title: string;
+    url?: string;
+  }): Wire<Schemas["PostView"]> {
+    const resolvedCommunity = over.community ?? community();
+
+    return {
+      banned_from_community: false,
+      community: resolvedCommunity,
+      counts: {
+        comments: 0,
+        cross_posts: 0,
+        downvotes: 0,
+        newest_comment_time: now,
+        post_id: over.id,
+        published: now,
+        score: 1,
+        upvotes: 1,
+      },
+      creator: over.creator,
+      creator_banned_from_community: false,
+      creator_is_admin: false,
+      creator_is_moderator: false,
+      hidden: false,
+      post: post({ ...over, community: resolvedCommunity }),
+      read: false,
+      saved: false,
+      subscribed: "NotSubscribed",
+      unread_comments: 0,
+    };
+  }
+
+  function commentView(over: {
+    body: string;
+    child_count?: number;
+    creator?: Wire<Schemas["Person"]>;
+    id: number;
+    path?: string;
+    post: Pick<Wire<Schemas["PostView"]>, "community" | "creator" | "post">;
+    published?: string;
+  }): Wire<Schemas["CommentView"]> {
+    const creator = over.creator ?? over.post.creator;
+    const published = over.published ?? now;
+
+    return {
+      activity_alert: false,
+      banned_from_community: false,
+      comment: {
+        ap_id: `https://${host}/comment/${over.id}`,
+        body: over.body,
+        deleted: false,
+        distinguished: false,
+        id: over.id,
+        language_id: 0,
+        local: true,
+        path: over.path ?? `0.${over.id}`,
+        post_id: over.post.post.id,
+        published,
+        removed: false,
+        user_id: creator.id,
+      },
+      community: over.post.community,
+      counts: {
+        child_count: over.child_count ?? 0,
+        comment_id: over.id,
+        downvotes: 0,
+        published,
+        score: 1,
+        upvotes: 1,
+      },
+      creator,
+      creator_banned_from_community: false,
+      creator_blocked: false,
+      creator_is_admin: false,
+      creator_is_moderator: false,
+      post: over.post.post,
+      saved: false,
+      subscribed: "NotSubscribed",
+    };
+  }
+
+  function personView(
+    subject: Wire<Schemas["Person"]>,
+  ): Wire<Schemas["PersonView"]> {
+    return {
+      activity_alert: false,
+      counts: {
+        comment_count: 0,
+        person_id: subject.id,
+        post_count: 0,
+      },
+      is_admin: false,
+      person: subject,
+    };
+  }
+
+  /** `GET /api/alpha/user` (getPersonDetails) */
+  function userResponse(
+    subject: Wire<Schemas["Person"]>,
+  ): Wire<Schemas["GetUserResponse"]> {
+    return {
+      comments: [],
+      moderates: [],
+      person_view: personView(subject),
+      posts: [],
+    };
+  }
+
+  /** `GET /api/alpha/community` (getCommunity) */
+  function communityResponse(
+    over: { community?: Wire<Schemas["Community"]> } = {},
+  ): Wire<Schemas["GetCommunityResponse"]> {
+    return {
+      community_view: communityView(over),
+      discussion_languages: [],
+      moderators: [],
+    };
+  }
+
+  /** `GET /api/alpha/site` (getSite) */
+  function getSiteResponse(
+    over: { name?: string } = {},
+  ): Wire<Schemas["GetSiteResponse"]> {
+    return {
+      admins: [],
+      site: {
+        actor_id: `https://${host}/`,
+        name: over.name ?? "Test piefed site",
+      },
+      version,
+    };
+  }
+
+  return {
+    commentView,
+    community,
+    communityResponse,
+    communityView,
+    getSiteResponse,
+    person,
+    personView,
+    post,
+    postView,
+    userResponse,
+  };
+}

--- a/src/testing/piefed/builders.ts
+++ b/src/testing/piefed/builders.ts
@@ -9,6 +9,8 @@
 import type { components } from "../../providers/piefed/schema";
 import type { Wire } from "../wire";
 
+import { DEFAULT_NOW } from "../lemmyv1/builders";
+
 export interface PiefedBuildersOptions {
   /** Bare hostname used in generated actor ids, e.g. `"piefed.test"` */
   host: string;
@@ -28,7 +30,7 @@ export type PiefedBuilders = ReturnType<typeof createPiefedBuilders>;
 
 export function createPiefedBuilders({
   host,
-  now = "2026-05-21T12:00:00.000Z",
+  now = DEFAULT_NOW,
   version = DEFAULT_PIEFED_VERSION,
 }: PiefedBuildersOptions) {
   function person(over: {
@@ -260,7 +262,24 @@ export function createPiefedBuilders({
     };
   }
 
+  /** `GET /api/alpha/post/list` (getPosts) response envelope */
+  function postListResponse(
+    posts: Wire<Schemas["PostView"]>[],
+    nextPage: null | string = null,
+  ): Wire<Schemas["ListPostsResponse"]> {
+    return { next_page: nextPage, posts };
+  }
+
+  /** `GET /api/alpha/comment/list` (getComments) response envelope */
+  function commentListResponse(
+    comments: Wire<Schemas["CommentView"]>[],
+    nextPage: null | string = null,
+  ): Wire<Schemas["ListCommentsResponse"]> {
+    return { comments, next_page: nextPage };
+  }
+
   return {
+    commentListResponse,
     commentView,
     community,
     communityResponse,
@@ -269,6 +288,7 @@ export function createPiefedBuilders({
     person,
     personView,
     post,
+    postListResponse,
     postView,
     userResponse,
   };

--- a/src/testing/piefed/index.ts
+++ b/src/testing/piefed/index.ts
@@ -19,9 +19,13 @@ export interface FakePiefedInstanceOptions {
  *
  * ```ts
  * fake.mock("GET /api/alpha/post/list", {
- *   json: { next_page: null, posts: [fake.build.postView({ ... })] },
+ *   json: fake.build.postListResponse([fake.build.postView({ ... })]),
  * });
  * ```
+ *
+ * Not yet default-mocked (no typed builders yet — unmocked requests 404
+ * loudly): the notification fan-out (`GET /api/alpha/user/replies`,
+ * `GET /api/alpha/user/mentions`, `GET /api/alpha/private_message/list`).
  */
 export class FakePiefedInstance extends FakeInstance {
   /** Wire-format builders bound to this instance's host */
@@ -43,10 +47,10 @@ export class FakePiefedInstance extends FakeInstance {
       json: build.getSiteResponse(),
     }));
     this.mock("GET /api/alpha/post/list", () => ({
-      json: { next_page: null, posts: [] },
+      json: build.postListResponse([]),
     }));
     this.mock("GET /api/alpha/comment/list", () => ({
-      json: { comments: [], next_page: null },
+      json: build.commentListResponse([]),
     }));
   }
 }

--- a/src/testing/piefed/index.ts
+++ b/src/testing/piefed/index.ts
@@ -1,0 +1,54 @@
+import { FakeInstance } from "../FakeInstance";
+import {
+  createPiefedBuilders,
+  DEFAULT_PIEFED_VERSION,
+  PiefedBuilders,
+} from "./builders";
+
+export interface FakePiefedInstanceOptions {
+  /** Bare hostname (no scheme) the fake instance answers for */
+  host?: string;
+  /** PieFed version reported via nodeinfo and `GET /api/alpha/site` */
+  version?: string;
+}
+
+/**
+ * `FakeInstance` pre-seeded with the PieFed routes an app touches at
+ * startup, each serving an empty default. Seed data with `mock()` and the
+ * typed builders on `build`:
+ *
+ * ```ts
+ * fake.mock("GET /api/alpha/post/list", {
+ *   json: { next_page: null, posts: [fake.build.postView({ ... })] },
+ * });
+ * ```
+ */
+export class FakePiefedInstance extends FakeInstance {
+  /** Wire-format builders bound to this instance's host */
+  readonly build: PiefedBuilders;
+
+  constructor({
+    host = "piefed.test",
+    version = DEFAULT_PIEFED_VERSION,
+  }: FakePiefedInstanceOptions = {}) {
+    super({ host, software: { name: "piefed", version } });
+
+    const build = createPiefedBuilders({ host, version });
+    this.build = build;
+
+    // Everything the piefed path touches at app startup. Function responders
+    // so each request gets a fresh object (no shared mutable state) and
+    // nothing is built unless actually requested.
+    this.mock("GET /api/alpha/site", () => ({
+      json: build.getSiteResponse(),
+    }));
+    this.mock("GET /api/alpha/post/list", () => ({
+      json: { next_page: null, posts: [] },
+    }));
+    this.mock("GET /api/alpha/comment/list", () => ({
+      json: { comments: [], next_page: null },
+    }));
+  }
+}
+
+export * from "./builders";

--- a/test/testing-fake-piefed.test.ts
+++ b/test/testing-fake-piefed.test.ts
@@ -19,19 +19,16 @@ function setup() {
   ];
 
   instance.mock("GET /api/alpha/post/list", {
-    json: { next_page: null, posts },
+    json: instance.build.postListResponse(posts),
   });
   instance.mock("GET /api/alpha/comment/list", {
-    json: {
-      comments: [
-        instance.build.commentView({
-          body: "A piefed comment",
-          id: 5001,
-          post: posts[0]!,
-        }),
-      ],
-      next_page: null,
-    },
+    json: instance.build.commentListResponse([
+      instance.build.commentView({
+        body: "A piefed comment",
+        id: 5001,
+        post: posts[0]!,
+      }),
+    ]),
   });
 
   const client = new ThreadiverseClient(

--- a/test/testing-fake-piefed.test.ts
+++ b/test/testing-fake-piefed.test.ts
@@ -1,0 +1,115 @@
+// Round-trip contract test for the PieFed testing package: a real
+// ThreadiverseClient (discovery → piefed adapter → compat → SafeClient Zod
+// validation) run against FakePiefedInstance. If a builder drifts from what
+// the compat layer + canonical schemas expect, this fails here — not in a
+// consumer's e2e suite.
+
+import { describe, expect, it } from "vitest";
+
+import { FakePiefedInstance } from "../src/testing";
+import ThreadiverseClient from "../src/ThreadiverseClient";
+
+function setup() {
+  const instance = new FakePiefedInstance({ host: "piefed.fake.test" });
+
+  const alex = instance.build.person({ id: 100, user_name: "alex" });
+  const posts = [
+    instance.build.postView({ creator: alex, id: 1, title: "First post" }),
+    instance.build.postView({ creator: alex, id: 2, title: "Second post" }),
+  ];
+
+  instance.mock("GET /api/alpha/post/list", {
+    json: { next_page: null, posts },
+  });
+  instance.mock("GET /api/alpha/comment/list", {
+    json: {
+      comments: [
+        instance.build.commentView({
+          body: "A piefed comment",
+          id: 5001,
+          post: posts[0]!,
+        }),
+      ],
+      next_page: null,
+    },
+  });
+
+  const client = new ThreadiverseClient(
+    instance.origin,
+    instance.clientOptions(),
+  );
+
+  return { alex, client, instance, posts };
+}
+
+describe("FakePiefedInstance + ThreadiverseClient round trip", () => {
+  it("discovers software via nodeinfo", async () => {
+    const { client } = setup();
+
+    expect(await client.connect()).toEqual({
+      mode: "piefed",
+      software: { name: "piefed", version: "1.2.0" },
+    });
+  });
+
+  it("getSite passes canonical validation", async () => {
+    const { client } = setup();
+
+    const site = await client.getSite();
+
+    expect(site.site_view.site.name).toBe("Test piefed site");
+  });
+
+  it("getPosts returns seeded posts through compat + validation", async () => {
+    const { client } = setup();
+
+    const { data } = await client.getPosts({});
+
+    expect(data.map((view) => view.post.name)).toEqual([
+      "First post",
+      "Second post",
+    ]);
+    expect(data[0]!.creator.name).toBe("alex");
+  });
+
+  it("getComments returns seeded comments through compat + validation", async () => {
+    const { client } = setup();
+
+    const { data } = await client.getComments({ post_id: 1 });
+
+    expect(data.map((view) => view.comment.content)).toEqual([
+      "A piefed comment",
+    ]);
+  });
+
+  it("getCommunity and getPersonDetails pass canonical validation", async () => {
+    const { alex, client, instance } = setup();
+
+    instance.mock("GET /api/alpha/community", {
+      json: instance.build.communityResponse(),
+    });
+    instance.mock("GET /api/alpha/user", {
+      json: instance.build.userResponse(alex),
+    });
+
+    const { community_view } = await client.getCommunity({
+      name: "test_comm",
+    });
+    expect(community_view.community.name).toBe("test_comm");
+
+    const { person_view } = await client.getPersonDetails({
+      username: "alex",
+    });
+    expect(person_view.person.name).toBe("alex");
+  });
+
+  it("records calls with query for assertions", async () => {
+    const { client, instance } = setup();
+
+    await client.getPosts({ limit: 20 });
+
+    const calls = instance.calls("GET /api/alpha/post/list");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.query.get("limit")).toBe("20");
+  });
+});


### PR DESCRIPTION
Adds the PieFed counterpart to `FakeLemmyV1Instance`:

- `createPiefedBuilders` — wire builders (`person`, `community`, `postView`, `commentView`, `communityView`, `getSiteResponse`, `userResponse`, `communityResponse`, …) typed against the OpenAPI-generated `components["schemas"]` that the piefed compat layer consumes, so a schema regen from live swagger turns fixture drift into compile errors
- `FakePiefedInstance` — `FakeInstance` pre-seeded with the `/api/alpha` app-startup routes (site, post/list, comment/list) as lazy empty defaults; discovery serves `{ name: "piefed" }`
- round-trip contract test: real `ThreadiverseClient` → discovery → piefed adapter → compat → canonical Zod, 6 scenarios (connect/site/posts/comments/community/person + call recording)

This unblocks provider-matrix e2e in Voyager (PieFed UI paths currently have zero e2e coverage). Lemmy v0 fake intentionally skipped per discussion — v0 is on its way out.