### PR TITLE
feat: error condition taxonomy (semantic Error subclasses)

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,16 +6,126 @@ import { PiefedErrorResponse } from "./types";
  * Machine-readable error codes a fediverse server may return (e.g.
  * "incorrect_login", "too_many_requests"), exposed on `ResponseError.code`.
  *
- * The known union gives autocomplete/exhaustiveness for the codes Lemmy
- * emits; software may emit codes outside it (PieFed, future Lemmy versions),
- * so any string is accepted. Match with `isErrorCode`.
+ * Escape hatch: prefer matching the condition subclasses with `instanceof`
+ * (`NotFoundError`, `RateLimitedError`, ...). Codes remain for conditions
+ * that don't have a class (the long tail) and for debugging.
  */
 export type ResponseErrorCode = LemmyErrorType["error"] | (string & {});
+
+export type ResponseErrorOptions = {
+  cause?: unknown;
+  /** PieFed's raw error payload, when the server provided one */
+  response?: PiefedErrorResponse;
+  software?: "lemmy" | "piefed";
+  status?: number;
+};
+
+type ResponseErrorConstructor = new (
+  code: string,
+  options?: ResponseErrorOptions,
+) => ResponseError;
 
 export class FediverseError extends Error {
   constructor(message: string, errorOptions?: ErrorOptions) {
     super(message, errorOptions);
     this.name = "FediverseError";
+  }
+}
+
+/**
+ * Thrown when a fediverse server returns an error response.
+ *
+ * The class encodes the *condition*: providers normalize their native error
+ * codes onto the condition subclasses below (`NotFoundError`,
+ * `RateLimitedError`, `IncorrectLoginError`, ...), so `instanceof` checks
+ * work identically across software. Unmapped codes surface as this base
+ * class.
+ *
+ * Details for the long tail and debugging: the raw machine-readable code is
+ * on `.code` (and `.message`, for legacy `error.message ===` checks), which
+ * software emitted it is on `.software`, HTTP status on `.status`, and the
+ * original underlying error (e.g. lemmy-js-client's `LemmyError`) on
+ * `.cause`.
+ */
+export class ResponseError extends FediverseError {
+  code: ResponseErrorCode;
+  /** PieFed's raw error payload, when the server provided one */
+  response?: PiefedErrorResponse;
+  software?: "lemmy" | "piefed";
+  status?: number;
+
+  constructor(code: string, options?: ResponseErrorOptions) {
+    super(
+      code,
+      options?.cause !== undefined ? { cause: options.cause } : undefined,
+    );
+    this.name = "ResponseError";
+    this.code = code;
+    this.response = options?.response;
+    this.software = options?.software;
+    this.status = options?.status;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Condition subclasses. Add a class (and its code mapping in
+// CONDITION_BY_CODE) when a consumer needs to branch on a condition — the
+// live error-fidelity suite verifies mappings against real instances.
+// ---------------------------------------------------------------------------
+
+/** The account has been deleted */
+export class AccountDeletedError extends ResponseError {
+  constructor(code: string, options?: ResponseErrorOptions) {
+    super(code, options);
+    this.name = "AccountDeletedError";
+  }
+}
+
+/** The account is banned from the instance */
+export class BannedError extends ResponseError {
+  constructor(code: string, options?: ResponseErrorOptions) {
+    super(code, options);
+    this.name = "BannedError";
+  }
+}
+
+/** Admins cannot be blocked */
+export class CantBlockAdminError extends ResponseError {
+  constructor(code: string, options?: ResponseErrorOptions) {
+    super(code, options);
+    this.name = "CantBlockAdminError";
+  }
+}
+
+/** The account's email address has not been verified yet */
+export class EmailNotVerifiedError extends ResponseError {
+  constructor(code: string, options?: ResponseErrorOptions) {
+    super(code, options);
+    this.name = "EmailNotVerifiedError";
+  }
+}
+
+/** Wrong or missing TOTP second factor */
+export class Incorrect2faError extends ResponseError {
+  constructor(code: string, options?: ResponseErrorOptions) {
+    super(code, options);
+    this.name = "Incorrect2faError";
+  }
+}
+
+/** Wrong username/email or password */
+export class IncorrectLoginError extends ResponseError {
+  constructor(code: string, options?: ResponseErrorOptions) {
+    super(code, options);
+    this.name = "IncorrectLoginError";
+  }
+}
+
+/** The action is not allowed for bot accounts */
+export class InvalidBotActionError extends ResponseError {
+  constructor(code: string, options?: ResponseErrorOptions) {
+    super(code, options);
+    this.name = "InvalidBotActionError";
   }
 }
 
@@ -27,56 +137,49 @@ export class InvalidPayloadError extends FediverseError {
 }
 
 /**
- * Thrown when a fediverse server returns an error response.
- *
- * Generic — use this when you don't care which software emitted it (e.g.,
- * mapping `error.code` or `error.status` to a toast). Software-specific
- * subclasses (`LemmyResponseError`, `PiefedResponseError`) extend this; check
- * with `instanceof` when business logic depends on the software.
- *
- * The error code (e.g. "incorrect_login", "too_many_requests") is exposed on
- * both `.code` (preferred) and `.message` (for legacy `error.message ===`
- * checks). HTTP status is on `.status` when known. The original underlying
- * error (e.g. lemmy-js-client's `LemmyError`) is attached as `.cause`.
+ * @deprecated Branch on the condition subclasses (`NotFoundError`, ...) or
+ * `error.software` instead. No longer thrown; retained for compatibility.
  */
-export class ResponseError extends FediverseError {
-  code: ResponseErrorCode;
-  status?: number;
-
-  constructor(code: string, options?: { cause?: unknown; status?: number }) {
-    super(
-      code,
-      options?.cause !== undefined ? { cause: options.cause } : undefined,
-    );
-    this.name = "ResponseError";
-    this.code = code;
-    this.status = options?.status;
-  }
-}
-
-/** Thrown when a Lemmy (v0 or v1) server returns an error response. */
 export class LemmyResponseError extends ResponseError {
-  constructor(code: string, options?: { cause?: unknown; status?: number }) {
-    super(code, options);
+  constructor(code: string, options?: ResponseErrorOptions) {
+    super(code, { ...options, software: "lemmy" });
     this.name = "LemmyResponseError";
   }
 }
 
-/** Thrown when a PieFed server returns an error response. */
-export class PiefedResponseError extends ResponseError {
-  response?: PiefedErrorResponse;
-
-  constructor(
-    code: string,
-    options?: {
-      cause?: unknown;
-      response?: PiefedErrorResponse;
-      status?: number;
-    },
-  ) {
+/** The requested entity (post, comment, community, person...) doesn't exist */
+export class NotFoundError extends ResponseError {
+  constructor(code: string, options?: ResponseErrorOptions) {
     super(code, options);
+    this.name = "NotFoundError";
+  }
+}
+
+/**
+ * @deprecated Branch on the condition subclasses (`NotFoundError`, ...) or
+ * `error.software` instead (raw payload is on `error.response`). No longer
+ * thrown; retained for compatibility.
+ */
+export class PiefedResponseError extends ResponseError {
+  constructor(code: string, options?: ResponseErrorOptions) {
+    super(code, { ...options, software: "piefed" });
     this.name = "PiefedResponseError";
-    this.response = options?.response;
+  }
+}
+
+/** The server is rate limiting the client */
+export class RateLimitedError extends ResponseError {
+  constructor(code: string, options?: ResponseErrorOptions) {
+    super(code, options);
+    this.name = "RateLimitedError";
+  }
+}
+
+/** Signup application is awaiting admin approval */
+export class RegistrationApplicationPendingError extends ResponseError {
+  constructor(code: string, options?: ResponseErrorOptions) {
+    super(code, options);
+    this.name = "RegistrationApplicationPendingError";
   }
 }
 
@@ -101,12 +204,48 @@ export class UnsupportedSoftwareError extends UnsupportedError {
   }
 }
 
+// Lemmy codes (v0 + v1). PieFed's native codes are mapped as the live
+// error-fidelity suite discovers them.
+const CONDITION_BY_CODE: Record<string, ResponseErrorConstructor> = {
+  cant_block_admin: CantBlockAdminError,
+  deleted: AccountDeletedError,
+  email_not_verified: EmailNotVerifiedError,
+  incorrect_login: IncorrectLoginError,
+  incorrect_totp_token: Incorrect2faError,
+  invalid_bot_action: InvalidBotActionError,
+  not_found: NotFoundError,
+  rate_limit_error: RateLimitedError,
+  registration_application_is_pending: RegistrationApplicationPendingError,
+  site_ban: BannedError,
+  too_many_requests: RateLimitedError,
+};
+
+/**
+ * Build the right `ResponseError` (condition subclass when the code maps to
+ * one) for a server error response. Providers throw through this so
+ * condition semantics stay identical across software.
+ */
+export function createResponseError(
+  code: string,
+  options?: ResponseErrorOptions,
+): ResponseError {
+  const Condition =
+    CONDITION_BY_CODE[code] ??
+    // Lemmy ≤0.19 entity-specific not-found codes
+    (code.startsWith("couldnt_find_") ? NotFoundError : undefined);
+
+  return Condition
+    ? new Condition(code, options)
+    : new ResponseError(code, options);
+}
+
 /**
  * Whether `error` is a server error response carrying the given
  * machine-readable code.
  *
- * Also matches on `.message` for non-`ResponseError` errors, preserving
- * legacy `error.message === "code"` semantics.
+ * Escape hatch: prefer `instanceof` on the condition subclasses. Also
+ * matches on `.message` for non-`ResponseError` errors, preserving legacy
+ * `error.message === "code"` semantics.
  */
 export function isErrorCode(error: unknown, code: ResponseErrorCode): boolean {
   if (error instanceof ResponseError) return error.code === code;

--- a/src/providers/lemmyv0/index.ts
+++ b/src/providers/lemmyv0/index.ts
@@ -6,8 +6,8 @@ import {
   RequestOptions,
 } from "../../BaseClient";
 import {
+  createResponseError,
   InvalidPayloadError,
-  LemmyResponseError,
   UnexpectedResponseError,
   UnsupportedError,
 } from "../../errors";
@@ -898,23 +898,19 @@ function toScore(is_upvote: boolean | undefined): number {
 /**
  * Wrap every method on the lemmy-js-client-v0 instance so that any thrown
  * `Error` (whose `.message` carries the server error code) becomes a
- * `LemmyResponseError`. Consumers can then `instanceof LemmyResponseError`
- * uniformly across v0 and v1, and the original error is preserved as `.cause`.
+ * `ResponseError` (condition subclass where the code maps to one).
+ * Consumers can then `instanceof` uniformly across v0 and v1, and the
+ * original error is preserved as `.cause`.
  */
 function wrapLemmyV0Errors(client: LemmyV0.LemmyHttp): LemmyV0.LemmyHttp {
   // The v0 client throws `new Error(json.error ?? statusText)` for server
   // error responses — i.e. plain `Error`, not a subclass. Transport-level
   // failures (e.g. `TypeError("Failed to fetch")` from the network) bubble up
-  // as their own subclass and should NOT be coerced into `LemmyResponseError`,
+  // as their own subclass and should NOT be coerced into `ResponseError`,
   // which is reserved for actual server responses.
   function normalize(err: unknown): never {
-    if (
-      err instanceof Error &&
-      err.constructor === Error &&
-      !(err instanceof LemmyResponseError) &&
-      err.message
-    ) {
-      throw new LemmyResponseError(err.message, { cause: err });
+    if (err instanceof Error && err.constructor === Error && err.message) {
+      throw createResponseError(err.message, { cause: err, software: "lemmy" });
     }
     throw err;
   }

--- a/src/providers/lemmyv1/index.ts
+++ b/src/providers/lemmyv1/index.ts
@@ -8,8 +8,8 @@ import {
   RequestOptions,
 } from "../../BaseClient";
 import {
+  createResponseError,
   InvalidPayloadError,
-  LemmyResponseError,
   UnsupportedError,
 } from "../../errors";
 import buildSafeClient from "../../SafeClient";
@@ -810,7 +810,11 @@ function normalizeError(err: unknown): unknown {
   // `fetch`, `AbortError`, etc.) must pass through unchanged — wrapping
   // them would mis-classify a network failure as a Lemmy error code.
   if (err instanceof LemmyV1.LemmyError) {
-    return new LemmyResponseError(err.name, { cause: err, status: err.status });
+    return createResponseError(err.name, {
+      cause: err,
+      software: "lemmy",
+      status: err.status,
+    });
   }
   return err;
 }

--- a/src/providers/piefed/index.ts
+++ b/src/providers/piefed/index.ts
@@ -6,8 +6,8 @@ import {
   RequestOptions,
 } from "../../BaseClient";
 import {
+  createResponseError,
   InvalidPayloadError,
-  PiefedResponseError,
   UnsupportedError,
 } from "../../errors";
 import buildSafeClient from "../../SafeClient";
@@ -44,8 +44,9 @@ async function validateResponse(response: Response) {
       // Non-JSON body (e.g., HTML error page from an upstream proxy).
       // Fall back to statusText already set above.
     }
-    throw new PiefedResponseError(code, {
+    throw createResponseError(code, {
       response: payload,
+      software: "piefed",
       status: response.status,
     });
   }

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,11 +1,57 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  createResponseError,
+  IncorrectLoginError,
   isErrorCode,
   LemmyResponseError,
+  NotFoundError,
+  RateLimitedError,
   ResponseError,
   UnsupportedError,
 } from "../src/errors";
+
+describe("createResponseError", () => {
+  it("maps known codes to condition subclasses", () => {
+    const error = createResponseError("incorrect_login", {
+      software: "lemmy",
+      status: 401,
+    });
+
+    expect(error).toBeInstanceOf(IncorrectLoginError);
+    expect(error).toBeInstanceOf(ResponseError);
+    expect(error.code).toBe("incorrect_login");
+    expect(error.message).toBe("incorrect_login");
+    expect(error.software).toBe("lemmy");
+    expect(error.status).toBe(401);
+  });
+
+  it("maps equivalent codes across versions to one condition", () => {
+    expect(createResponseError("rate_limit_error")).toBeInstanceOf(
+      RateLimitedError,
+    );
+    expect(createResponseError("too_many_requests")).toBeInstanceOf(
+      RateLimitedError,
+    );
+  });
+
+  it("maps lemmy ≤0.19 entity-specific not-found codes", () => {
+    expect(createResponseError("couldnt_find_person")).toBeInstanceOf(
+      NotFoundError,
+    );
+    expect(createResponseError("not_found")).toBeInstanceOf(NotFoundError);
+  });
+
+  it("falls back to the base class for unmapped codes", () => {
+    const error = createResponseError("some_new_code", {
+      software: "piefed",
+    });
+
+    expect(error.constructor).toBe(ResponseError);
+    expect(error.code).toBe("some_new_code");
+    expect(error.software).toBe("piefed");
+  });
+});
 
 describe("isErrorCode", () => {
   it("matches ResponseError by code", () => {


### PR DESCRIPTION
Per API workshop with the consumer in mind: consumers branch on error *conditions* (wrong password, rate limited, not found), never on which software emitted them — so the class axis now encodes the condition.

- `createResponseError(code, { software, status, cause, response })` factory: maps native codes → condition subclasses (`NotFoundError` incl. lemmy ≤0.19 `couldnt_find_*`, `RateLimitedError` for both `rate_limit_error`/`too_many_requests`, `IncorrectLoginError`, `Incorrect2faError`, `EmailNotVerifiedError`, `BannedError`, `AccountDeletedError`, `RegistrationApplicationPendingError`, `InvalidBotActionError`, `CantBlockAdminError`); unmapped → `ResponseError` base
- All three providers throw through the factory; raw `.code`/`.message`, `.software`, `.status`, `.response` (PieFed payload) retained as long-tail/debugging details
- `LemmyResponseError`/`PiefedResponseError` deprecated (no longer thrown); `ResponseErrorCode`/`isErrorCode` demoted to escape hatch
- Voyager's `lemmyErrors.ts` switch becomes provider-agnostic `instanceof` checks — PieFed login errors will finally map to real messages once its native codes are added to the table
- PieFed's native code mappings are intentionally sparse until the live error-fidelity suite (docs/testing-plan.md on `testing-seed-layer`) discovers the real wire codes

365 tests green; behavior unchanged for consumers matching `error.message` (still the code).