### PR TITLE
feat(testing): semantic seed store + operation layer

### DIFF
--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -1,6 +1,9 @@
 # threadiverse/testing — design & roadmap
 
-Status: seed layer in progress on `testing-seed-layer` (2026-07-02).
+Status (2026-07-02): layers 1–3 implemented (seed store + derived routes,
+`on`/`once`/`callsTo` with canonical error injection, provider-matrix test
+green on lemmyv1 + piefed; error condition taxonomy in #53). Next: fidelity
+suite, then Voyager adoption.
 Owners: consumer test devex for Voyager and other clients.
 
 ## Goal

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -1,0 +1,95 @@
+# threadiverse/testing — design & roadmap
+
+Status: seed layer in progress on `testing-seed-layer` (2026-07-02).
+Owners: consumer test devex for Voyager and other clients.
+
+## Goal
+
+Consumer tests should describe **what exists and what happens** — never
+provider wire formats or HTTP routes. Wire knowledge lives in this package,
+type-checked against the same upstream types the compat layers consume, and
+**verified against real instances** so the fakes can't drift from reality.
+
+## The three layers
+
+| Layer | API | Use for |
+| --- | --- | --- |
+| Content | `fake.seed.*` | What exists: people, communities, posts, comments, notifications, logged-in user. All read endpoints derive consistently from one store. |
+| Behavior | `fake.on.*` / `fake.once.*` | Per-operation overrides keyed by threadiverse endpoint name (provider-agnostic): error injection (canonical `{ code, status }`), custom wire responses (typed via `fake.build.*`), one-shot sequencing. |
+| Escape hatch | `fake.mock(matcher, responder)` | Anything else, at the HTTP route level. Discouraged in consumer specs. |
+
+Request assertions: `fake.callsTo("likePost")` / `fake.waitForCallTo(...)` —
+operation-keyed views over the existing recording.
+
+```ts
+const fake = new FakeLemmyV1Instance();
+
+// content
+const alex = fake.seed.person({ name: "alex" });
+fake.seed.post({ name: "Hello **world**", creator: alex });
+fake.seed.loggedInAs(alex);
+
+// behavior
+fake.once.getSite({ error: { code: "rate_limited", status: 400 } });
+fake.on.getPosts({ json: fake.build.pagedResponse([/* custom wire */]) });
+```
+
+### Design decisions
+
+- **Operation → route maps** per provider power `on`/`once`/`callsTo` and
+  double as route documentation (kills route-string duplication).
+- **Success overrides stay wire-typed** (`fake.build.*`). A general
+  canonical→wire reverse-compat layer is deliberately out of scope: it would
+  double compat maintenance and is lossy/underdetermined for some fields.
+- **Errors are canonical**: `{ code, status? }` renders to each provider's
+  error wire shape (Lemmy `{ error }`, PieFed `{ message }`). Error injection
+  is the #1 reason specs currently drop to wire level.
+- **`once` over stateful writes**: sequencing (fail-then-succeed,
+  subscribe-flow state changes) is explicit via one-shot queues. Writes
+  mutating the seed store (a fully stateful fake server) is deferred until a
+  real spec needs it.
+
+## Fidelity verification (fakes must match reality)
+
+The fakes are only trustworthy if their responses — **especially error
+responses** — match what real Lemmy/PieFed instances send. Scheduled e2e in
+this repo (extends the live-smoke approach; read-only, polite):
+
+1. **Error fidelity** (`test/live-fidelity.test.ts`): deterministic,
+   read-only error probes against live instances — nonexistent community,
+   nonexistent user, unauthenticated account endpoint, malformed params.
+   For each scenario:
+   - capture the real instance's status + error body;
+   - render the fake's error for the same scenario;
+   - assert same status, same body key-set, same machine-readable code; and
+   - drive both through a real `ThreadiverseClient` and assert the identical
+     `ResponseError` code surfaces.
+2. **Read-path fidelity**: for each derived GET endpoint, fetch a real
+   response and the fake's response for an equivalent seed; assert the
+   fake's key-set/types are a structural match (allowlist for known
+   content-dependent optionals). Both must survive the same compat +
+   canonical Zod pipeline.
+3. **Recorded snapshots**: sanitized real responses checked in as fixtures
+   and refreshed by the scheduled job, so fidelity regressions show up as
+   reviewable diffs rather than only red CI.
+4. **Later — dockerized instances**: Lemmy 1.0-beta + PieFed via compose for
+   write-path fidelity and v1 coverage no public instance provides.
+   Separate decision (seed harness maintenance cost).
+
+## Sequencing
+
+1. **Finish `testing-seed-layer`** (this branch): seed store + derived
+   routes for both fakes; `on`/`once`/`callsTo` + operation route maps +
+   canonical error rendering; provider-matrix round-trip test (seed once,
+   assert through the client on both fakes). PR → review → merge.
+2. **Fidelity suite** (new PR): error-fidelity scenarios first (highest
+   signal, cheapest), then read-path structural checks + snapshots; weekly
+   workflow alongside live-smoke.
+3. **Voyager adoption branch** (`feat/threadiverse-testing`, in flight):
+   rebuild `MockApi` on seed + `on`/`once` (auth via `seed.loggedInAs`,
+   inbox via seed notifications), first PieFed e2e specs, `lemmyErrors` →
+   `isErrorCode` (done). Parked until release; only needs the version pin.
+4. **Release** (end of effort, per policy), then the Voyager PR.
+5. **Backlog**: port `lemmyv1-vote-payload`/`lemmyv1-compat` tests onto the
+   typed builders; `subscribed`-post/`mod_action` + PieFed notification
+   builders; stateful writes if a spec demands it; docker decision.

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -12,11 +12,11 @@ type-checked against the same upstream types the compat layers consume, and
 
 ## The three layers
 
-| Layer | API | Use for |
-| --- | --- | --- |
-| Content | `fake.seed.*` | What exists: people, communities, posts, comments, notifications, logged-in user. All read endpoints derive consistently from one store. |
-| Behavior | `fake.on.*` / `fake.once.*` | Per-operation overrides keyed by threadiverse endpoint name (provider-agnostic): error injection (canonical `{ code, status }`), custom wire responses (typed via `fake.build.*`), one-shot sequencing. |
-| Escape hatch | `fake.mock(matcher, responder)` | Anything else, at the HTTP route level. Discouraged in consumer specs. |
+| Layer        | API                             | Use for                                                                                                                                                                                                 |
+| ------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Content      | `fake.seed.*`                   | What exists: people, communities, posts, comments, notifications, logged-in user. All read endpoints derive consistently from one store.                                                                |
+| Behavior     | `fake.on.*` / `fake.once.*`     | Per-operation overrides keyed by threadiverse endpoint name (provider-agnostic): error injection (canonical `{ code, status }`), custom wire responses (typed via `fake.build.*`), one-shot sequencing. |
+| Escape hatch | `fake.mock(matcher, responder)` | Anything else, at the HTTP route level. Discouraged in consumer specs.                                                                                                                                  |
 
 Request assertions: `fake.callsTo("likePost")` / `fake.waitForCallTo(...)` —
 operation-keyed views over the existing recording.
@@ -31,7 +31,11 @@ fake.seed.loggedInAs(alex);
 
 // behavior
 fake.once.getSite({ error: { code: "rate_limited", status: 400 } });
-fake.on.getPosts({ json: fake.build.pagedResponse([/* custom wire */]) });
+fake.on.getPosts({
+  json: fake.build.pagedResponse([
+    /* custom wire */
+  ]),
+});
 ```
 
 ### Design decisions

--- a/src/testing/FakeInstance.ts
+++ b/src/testing/FakeInstance.ts
@@ -17,6 +17,12 @@ import type { ThreadiverseClientOptions } from "../ThreadiverseClient";
 
 import { DiscoveryCache, Nodeinfo21Payload, NodeinfoLink } from "../wellknown";
 
+/**
+ * Canonical error injection: rendered into the provider's error wire shape
+ * (verified against real instances by the live error-fidelity suite).
+ */
+export type ErrorInjection = { code: string; status?: number };
+
 export interface FakeInstanceOptions {
   /** Bare hostname (no scheme), e.g. `"v1.test.lemmy"` */
   host: string;
@@ -41,6 +47,27 @@ export type FakeResponse =
 
 /** `"METHOD /path"` — matched against pathname only (query ignored) */
 export type Matcher = `${"DELETE" | "GET" | "POST" | "PUT"} /${string}`;
+
+export interface OperationApi<Operation extends string> {
+  /** Recorded requests for an operation (by name, not route) */
+  callsTo(operation: Operation): RecordedCall[];
+  /** Override an operation's response. Last call wins. */
+  on: Record<Operation, (responder: OperationResponder) => void>;
+  /** Override an operation's next response only, then fall back. */
+  once: Record<Operation, (responder: OperationResponder) => void>;
+  /** Wait until a request for an operation is recorded. */
+  waitForCallTo(
+    operation: Operation,
+    predicate?: (call: RecordedCall) => boolean,
+    options?: { timeoutMs?: number },
+  ): Promise<RecordedCall>;
+}
+
+export type OperationResponder =
+  | ((call: RecordedCall) => OperationResponse | Promise<OperationResponse>)
+  | OperationResponse;
+
+export type OperationResponse = FakeResponse | { error: ErrorInjection };
 
 export type RecordedCall = {
   body: unknown;
@@ -102,6 +129,8 @@ export class FakeInstance {
   #discoveryCache: DiscoveryCache = new Map();
 
   #handlers = new Map<Matcher, Responder>();
+
+  #onceQueues = new Map<Matcher, Responder[]>();
 
   #waiters: Waiter[] = [];
 
@@ -207,9 +236,12 @@ export class FakeInstance {
     this.#calls.push(call);
     this.#notifyWaiters(call);
 
-    const responder = this.#handlers.get(
-      `${request.method} ${url.pathname}` as Matcher,
-    );
+    const matcher = `${request.method} ${url.pathname}` as Matcher;
+
+    const onceQueue = this.#onceQueues.get(matcher);
+    const responder = onceQueue?.length
+      ? onceQueue.shift()
+      : this.#handlers.get(matcher);
 
     if (!responder) {
       // Surface missing mocks loudly instead of letting requests escape to
@@ -258,6 +290,13 @@ export class FakeInstance {
     this.#handlers.set(matcher, responder);
   }
 
+  /** Respond once for an endpoint, then fall back to the standing mock. */
+  mockOnce(matcher: Matcher, responder: Responder): void {
+    const queue = this.#onceQueues.get(matcher) ?? [];
+    queue.push(responder);
+    this.#onceQueues.set(matcher, queue);
+  }
+
   /**
    * Wait until a matching request is recorded, then return the latest.
    * Resolution is push-based (no polling), so pending waiters settle the
@@ -292,6 +331,42 @@ export class FakeInstance {
 
       this.#waiters.push(waiter);
     });
+  }
+
+  /**
+   * Build the operation-level API (`on`/`once`/`callsTo`/`waitForCallTo`)
+   * from a provider's operation → route map plus its error wire renderer.
+   */
+  protected buildOperationApi<Operation extends string>(
+    routes: Record<Operation, Matcher>,
+    renderError: (error: ErrorInjection) => FakeResponse,
+  ): OperationApi<Operation> {
+    const toResponder = (responder: OperationResponder): Responder => {
+      const render = (response: OperationResponse): FakeResponse =>
+        "error" in response ? renderError(response.error) : response;
+
+      return typeof responder === "function"
+        ? async (call) => render(await responder(call))
+        : render(responder);
+    };
+
+    const on = {} as OperationApi<Operation>["on"];
+    const once = {} as OperationApi<Operation>["once"];
+
+    for (const operation of Object.keys(routes) as Operation[]) {
+      on[operation] = (responder) =>
+        this.mock(routes[operation], toResponder(responder));
+      once[operation] = (responder) =>
+        this.mockOnce(routes[operation], toResponder(responder));
+    }
+
+    return {
+      callsTo: (operation) => this.calls(routes[operation]),
+      on,
+      once,
+      waitForCallTo: (operation, predicate, options) =>
+        this.waitForCall(routes[operation], predicate, options),
+    };
   }
 
   #notifyWaiters(call: RecordedCall): void {

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,4 +1,5 @@
 export * from "./FakeInstance";
 export * from "./lemmyv1";
 export * from "./piefed";
+export * from "./seed";
 export type * from "./wire";

--- a/src/testing/lemmyv1/builders.ts
+++ b/src/testing/lemmyv1/builders.ts
@@ -375,17 +375,34 @@ export function createLemmyV1Builders({
   }
 
   /** `GET /api/v4/community` (getCommunity) */
+  function communityView(
+    over: { community?: Wire<LemmyV1.Community> } = {},
+  ): Wire<LemmyV1.CommunityView> {
+    return {
+      can_mod: false,
+      community: over.community ?? community(),
+      tags: [],
+    };
+  }
+
   function communityResponse(
     over: { community?: Wire<LemmyV1.Community> } = {},
   ): Wire<LemmyV1.GetCommunityResponse> {
     return {
-      community_view: {
-        can_mod: false,
-        community: over.community ?? community(),
-        tags: [],
-      },
+      community_view: communityView(over),
       discussion_languages: [],
       moderators: [],
+    };
+  }
+
+  /** `GET /api/v4/post` (getPost) */
+  function postResponse(
+    view: Wire<LemmyV1.PostView>,
+  ): Wire<LemmyV1.GetPostResponse> {
+    return {
+      community_view: communityView({ community: view.community }),
+      cross_posts: [],
+      post_view: view,
     };
   }
 
@@ -497,6 +514,7 @@ export function createLemmyV1Builders({
     commentView,
     community,
     communityResponse,
+    communityView,
     getSiteResponse,
     localUser,
     modlogView,
@@ -505,6 +523,7 @@ export function createLemmyV1Builders({
     person,
     personResponse,
     post,
+    postResponse,
     postView,
     privateMessageNotification,
     privateMessageView,

--- a/src/testing/lemmyv1/index.ts
+++ b/src/testing/lemmyv1/index.ts
@@ -243,7 +243,7 @@ export class FakeLemmyV1Instance extends FakeInstance {
 
     this.mock("GET /api/v4/account/notification/list", (call) => {
       const type = call.query.get("type_");
-      const notifications =
+      let notifications =
         type && type !== "all"
           ? seed.notifications.filter((notification) =>
               type === "private_message"
@@ -251,6 +251,10 @@ export class FakeLemmyV1Instance extends FakeInstance {
                 : notification.kind === type,
             )
           : seed.notifications;
+      if (call.query.get("unread_only") === "true")
+        notifications = notifications.filter(
+          (notification) => !notification.read,
+        );
       return {
         json: build.pagedResponse(notifications.map(notificationView)),
       };

--- a/src/testing/lemmyv1/index.ts
+++ b/src/testing/lemmyv1/index.ts
@@ -1,4 +1,4 @@
-import { FakeInstance } from "../FakeInstance";
+import { FakeInstance, Matcher, OperationApi } from "../FakeInstance";
 import {
   SeedComment,
   SeedCommunity,
@@ -13,12 +13,50 @@ import {
   LemmyV1Builders,
 } from "./builders";
 
+/**
+ * Operation → route map (threadiverse `BaseClient` endpoint names; routes
+ * verified against lemmy-js-client-v1). Powers `on`/`once`/`callsTo`.
+ */
+const LEMMY_V1_ROUTES = {
+  createComment: "POST /api/v4/comment",
+  createPost: "POST /api/v4/post",
+  createPrivateMessage: "POST /api/v4/private_message",
+  deleteComment: "DELETE /api/v4/comment",
+  deletePost: "DELETE /api/v4/post",
+  editComment: "PUT /api/v4/comment",
+  editPost: "PUT /api/v4/post",
+  followCommunity: "POST /api/v4/community/follow",
+  getComments: "GET /api/v4/comment/list",
+  getCommunity: "GET /api/v4/community",
+  getModlog: "GET /api/v4/modlog",
+  getNotifications: "GET /api/v4/account/notification/list",
+  getPersonDetails: "GET /api/v4/person",
+  getPost: "GET /api/v4/post",
+  getPosts: "GET /api/v4/post/list",
+  getRandomCommunity: "GET /api/v4/community/random",
+  getSite: "GET /api/v4/site",
+  getSiteMetadata: "GET /api/v4/post/site_metadata",
+  getUnreadCount: "GET /api/v4/account/unread_counts",
+  likeComment: "POST /api/v4/comment/like",
+  likePost: "POST /api/v4/post/like",
+  listPersonContent: "GET /api/v4/person/content",
+  login: "POST /api/v4/account/auth/login",
+  markNotificationAsRead: "POST /api/v4/account/notification/mark_as_read",
+  markPostAsRead: "POST /api/v4/post/mark_as_read/many",
+  resolveObject: "GET /api/v4/resolve_object",
+  saveComment: "PUT /api/v4/comment/save",
+  savePost: "PUT /api/v4/post/save",
+  search: "GET /api/v4/search",
+} satisfies Record<string, Matcher>;
+
 export interface FakeLemmyV1InstanceOptions {
   /** Bare hostname (no scheme) the fake instance answers for */
   host?: string;
   /** Lemmy version reported via nodeinfo and `GET /api/v4/site` */
   version?: string;
 }
+
+export type LemmyV1Operation = keyof typeof LEMMY_V1_ROUTES;
 
 /**
  * `FakeInstance` for Lemmy v1 whose default routes are derived, per
@@ -41,8 +79,20 @@ export class FakeLemmyV1Instance extends FakeInstance {
   /** Wire-format builders bound to this instance's host */
   readonly build: LemmyV1Builders;
 
+  /** Recorded requests for an operation (by name, not route) */
+  readonly callsTo: OperationApi<LemmyV1Operation>["callsTo"];
+
+  /** Override an operation's response (canonical `{ error }` supported) */
+  readonly on: OperationApi<LemmyV1Operation>["on"];
+
+  /** Override an operation's next response only, then fall back */
+  readonly once: OperationApi<LemmyV1Operation>["once"];
+
   /** Semantic content store the default routes are derived from */
   readonly seed = new SeedStore();
+
+  /** Wait until a request for an operation is recorded */
+  readonly waitForCallTo: OperationApi<LemmyV1Operation>["waitForCallTo"];
 
   constructor({
     host = "v1.test.lemmy",
@@ -53,6 +103,15 @@ export class FakeLemmyV1Instance extends FakeInstance {
     const build = createLemmyV1Builders({ host, version });
     this.build = build;
     const seed = this.seed;
+
+    const api = this.buildOperationApi(LEMMY_V1_ROUTES, (error) => ({
+      json: { error: error.code },
+      status: error.status ?? 400,
+    }));
+    this.callsTo = api.callsTo;
+    this.on = api.on;
+    this.once = api.once;
+    this.waitForCallTo = api.waitForCallTo;
 
     // seed → wire
     const person = (subject: SeedPerson) =>

--- a/src/testing/lemmyv1/index.ts
+++ b/src/testing/lemmyv1/index.ts
@@ -1,5 +1,13 @@
 import { FakeInstance } from "../FakeInstance";
 import {
+  SeedComment,
+  SeedCommunity,
+  SeedNotification,
+  SeedPerson,
+  SeedPost,
+  SeedStore,
+} from "../seed";
+import {
   createLemmyV1Builders,
   DEFAULT_VERSION,
   LemmyV1Builders,
@@ -13,19 +21,28 @@ export interface FakeLemmyV1InstanceOptions {
 }
 
 /**
- * `FakeInstance` pre-seeded with the Lemmy v1 routes an app touches at
- * startup, each serving an empty default. Seed data with `mock()` and the
- * typed builders on `build`:
+ * `FakeInstance` for Lemmy v1 whose default routes are derived, per
+ * request, from the semantic `seed` store — tests describe what exists,
+ * not which endpoint returns it:
  *
  * ```ts
- * fake.mock("GET /api/v4/post/list", {
- *   json: fake.build.pagedResponse([fake.build.postView({ ... })]),
- * });
+ * const alex = fake.seed.person({ name: "alex" });
+ * fake.seed.post({ name: "Hello **world**", creator: alex });
+ * fake.seed.loggedInAs(alex);
  * ```
+ *
+ * Derived: site, post list/detail, comment list, community, person (+
+ * person content), account, unread counts, notifications, modlog. Use
+ * `mock()` for error injection or endpoints outside this set, and
+ * `calls()` / `waitForCall()` to assert on outgoing requests. Wire-level
+ * builders stay available on `build`.
  */
 export class FakeLemmyV1Instance extends FakeInstance {
   /** Wire-format builders bound to this instance's host */
   readonly build: LemmyV1Builders;
+
+  /** Semantic content store the default routes are derived from */
+  readonly seed = new SeedStore();
 
   constructor({
     host = "v1.test.lemmy",
@@ -35,20 +52,155 @@ export class FakeLemmyV1Instance extends FakeInstance {
 
     const build = createLemmyV1Builders({ host, version });
     this.build = build;
+    const seed = this.seed;
 
-    // Everything the v1 path touches at app startup. Function responders so
-    // each request gets a fresh object (no shared mutable state) and nothing
-    // is built unless actually requested.
-    this.mock("GET /api/v4/site", () => ({ json: build.getSiteResponse() }));
+    // seed → wire
+    const person = (subject: SeedPerson) =>
+      build.person({
+        display_name: subject.displayName,
+        id: subject.id,
+        name: subject.name,
+      });
+    const community = (subject: SeedCommunity) =>
+      build.community({
+        id: subject.id,
+        name: subject.name,
+        title: subject.title,
+      });
+    const postView = (subject: SeedPost) =>
+      build.postView({
+        body: subject.body,
+        community: community(subject.community),
+        creator: person(subject.creator),
+        id: subject.id,
+        name: subject.name,
+        url: subject.url,
+      });
+    const commentView = (subject: SeedComment) =>
+      build.commentView({
+        child_count: subject.childCount,
+        content: subject.content,
+        creator: person(subject.creator),
+        id: subject.id,
+        path: subject.path,
+        post: postView(subject.post),
+        published_at: subject.published,
+      });
+    const notificationView = (subject: SeedNotification) =>
+      subject.kind === "private_message"
+        ? build.privateMessageNotification({
+            id: subject.id,
+            message: build.privateMessageView({
+              content: subject.message.content,
+              creator: person(subject.message.creator),
+              id: subject.message.id,
+              recipient: person(subject.message.recipient),
+            }),
+            read: subject.read,
+          })
+        : build.commentNotification({
+            comment: commentView(subject.comment),
+            id: subject.id,
+            kind: subject.kind,
+            read: subject.read,
+            recipient_id: seed.loggedInPerson?.id ?? 0,
+          });
+
+    const notFound = { json: { error: "not_found" }, status: 404 } as const;
+
+    this.mock("GET /api/v4/site", () => ({
+      json: build.getSiteResponse({
+        name: seed.siteName,
+        posts: seed.posts.length,
+      }),
+    }));
+
     this.mock("GET /api/v4/post/list", () => ({
-      json: build.pagedResponse([]),
+      json: build.pagedResponse(seed.posts.map(postView)),
     }));
-    this.mock("GET /api/v4/comment/list", () => ({
-      json: build.pagedResponse([]),
-    }));
+
+    this.mock("GET /api/v4/post", (call) => {
+      const post = seed.posts.find(
+        (candidate) => candidate.id === Number(call.query.get("id")),
+      );
+      return post ? { json: build.postResponse(postView(post)) } : notFound;
+    });
+
+    this.mock("GET /api/v4/comment/list", (call) => {
+      const postId = call.query.get("post_id");
+      const comments = postId
+        ? seed.comments.filter((comment) => comment.post.id === Number(postId))
+        : seed.comments;
+      return { json: build.pagedResponse(comments.map(commentView)) };
+    });
+
+    this.mock("GET /api/v4/community", (call) => {
+      const name = call.query.get("name")?.split("@")[0];
+      const found = seed.communities.find(
+        (candidate) => candidate.name === name,
+      );
+      return found
+        ? { json: build.communityResponse({ community: community(found) }) }
+        : notFound;
+    });
+
+    this.mock("GET /api/v4/person", (call) => {
+      const username = call.query.get("username")?.split("@")[0];
+      const found = seed.people.find(
+        (candidate) => candidate.name === username,
+      );
+      return found ? { json: build.personResponse(person(found)) } : notFound;
+    });
+
+    this.mock("GET /api/v4/person/content", (call) => {
+      const personId = Number(call.query.get("person_id"));
+      const items = [
+        ...seed.posts
+          .filter((post) => post.creator.id === personId)
+          .map((post) => ({ type_: "post" as const, ...postView(post) })),
+        ...seed.comments
+          .filter((comment) => comment.creator.id === personId)
+          .map((comment) => ({
+            type_: "comment" as const,
+            ...commentView(comment),
+          })),
+      ];
+      return { json: build.pagedResponse(items) };
+    });
+
     this.mock("GET /api/v4/modlog", () => ({
       json: build.pagedResponse([]),
     }));
+
+    this.mock("GET /api/v4/account", () =>
+      seed.loggedInPerson
+        ? { json: build.myUserInfo({ person: person(seed.loggedInPerson) }) }
+        : { json: { error: "not_logged_in" }, status: 401 },
+    );
+
+    this.mock("GET /api/v4/account/unread_counts", () => ({
+      json: { notification_count: seed.unreadNotificationCount },
+    }));
+
+    this.mock("GET /api/v4/account/notification/list", (call) => {
+      const type = call.query.get("type_");
+      const notifications =
+        type && type !== "all"
+          ? seed.notifications.filter((notification) =>
+              type === "private_message"
+                ? notification.kind === "private_message"
+                : notification.kind === type,
+            )
+          : seed.notifications;
+      return {
+        json: build.pagedResponse(notifications.map(notificationView)),
+      };
+    });
+
+    // Fire-and-forget side effect of many logged-in interactions
+    this.mock("POST /api/v4/post/mark_as_read/many", {
+      json: { success: true },
+    });
   }
 }
 

--- a/src/testing/piefed/index.ts
+++ b/src/testing/piefed/index.ts
@@ -1,5 +1,12 @@
 import { FakeInstance } from "../FakeInstance";
 import {
+  SeedComment,
+  SeedCommunity,
+  SeedPerson,
+  SeedPost,
+  SeedStore,
+} from "../seed";
+import {
   createPiefedBuilders,
   DEFAULT_PIEFED_VERSION,
   PiefedBuilders,
@@ -13,23 +20,27 @@ export interface FakePiefedInstanceOptions {
 }
 
 /**
- * `FakeInstance` pre-seeded with the PieFed routes an app touches at
- * startup, each serving an empty default. Seed data with `mock()` and the
- * typed builders on `build`:
+ * `FakeInstance` for PieFed whose default routes are derived, per request,
+ * from the semantic `seed` store — tests describe what exists, not which
+ * endpoint returns it:
  *
  * ```ts
- * fake.mock("GET /api/alpha/post/list", {
- *   json: fake.build.postListResponse([fake.build.postView({ ... })]),
- * });
+ * const alex = fake.seed.person({ name: "alex" });
+ * fake.seed.post({ name: "Hello **world**", creator: alex });
  * ```
  *
- * Not yet default-mocked (no typed builders yet — unmocked requests 404
- * loudly): the notification fan-out (`GET /api/alpha/user/replies`,
- * `GET /api/alpha/user/mentions`, `GET /api/alpha/private_message/list`).
+ * Derived: site, post list/detail, comment list, community, person. Use
+ * `mock()` for error injection or endpoints outside this set (notably the
+ * notification fan-out — `GET /api/alpha/user/replies`, `/user/mentions`,
+ * `/private_message/list` — which has no typed builders yet and 404s
+ * loudly when unmocked). Wire-level builders stay available on `build`.
  */
 export class FakePiefedInstance extends FakeInstance {
   /** Wire-format builders bound to this instance's host */
   readonly build: PiefedBuilders;
+
+  /** Semantic content store the default routes are derived from */
+  readonly seed = new SeedStore();
 
   constructor({
     host = "piefed.test",
@@ -39,19 +50,83 @@ export class FakePiefedInstance extends FakeInstance {
 
     const build = createPiefedBuilders({ host, version });
     this.build = build;
+    const seed = this.seed;
 
-    // Everything the piefed path touches at app startup. Function responders
-    // so each request gets a fresh object (no shared mutable state) and
-    // nothing is built unless actually requested.
+    // seed → wire
+    const person = (subject: SeedPerson) =>
+      build.person({
+        id: subject.id,
+        title: subject.displayName,
+        user_name: subject.name,
+      });
+    const community = (subject: SeedCommunity) =>
+      build.community({
+        id: subject.id,
+        name: subject.name,
+        title: subject.title,
+      });
+    const postView = (subject: SeedPost) =>
+      build.postView({
+        body: subject.body,
+        community: community(subject.community),
+        creator: person(subject.creator),
+        id: subject.id,
+        title: subject.name,
+        url: subject.url,
+      });
+    const commentView = (subject: SeedComment) =>
+      build.commentView({
+        body: subject.content,
+        child_count: subject.childCount,
+        creator: person(subject.creator),
+        id: subject.id,
+        path: subject.path,
+        post: postView(subject.post),
+        published: subject.published,
+      });
+
+    const notFound = { json: { error: "not_found" }, status: 404 } as const;
+
     this.mock("GET /api/alpha/site", () => ({
-      json: build.getSiteResponse(),
+      json: build.getSiteResponse({ name: seed.siteName }),
     }));
+
     this.mock("GET /api/alpha/post/list", () => ({
-      json: build.postListResponse([]),
+      json: build.postListResponse(seed.posts.map(postView)),
     }));
-    this.mock("GET /api/alpha/comment/list", () => ({
-      json: build.commentListResponse([]),
-    }));
+
+    this.mock("GET /api/alpha/post", (call) => {
+      const post = seed.posts.find(
+        (candidate) => candidate.id === Number(call.query.get("id")),
+      );
+      return post ? { json: { post_view: postView(post) } } : notFound;
+    });
+
+    this.mock("GET /api/alpha/comment/list", (call) => {
+      const postId = call.query.get("post_id");
+      const comments = postId
+        ? seed.comments.filter((comment) => comment.post.id === Number(postId))
+        : seed.comments;
+      return { json: build.commentListResponse(comments.map(commentView)) };
+    });
+
+    this.mock("GET /api/alpha/community", (call) => {
+      const name = call.query.get("name")?.split("@")[0];
+      const found = seed.communities.find(
+        (candidate) => candidate.name === name,
+      );
+      return found
+        ? { json: build.communityResponse({ community: community(found) }) }
+        : notFound;
+    });
+
+    this.mock("GET /api/alpha/user", (call) => {
+      const username = call.query.get("username")?.split("@")[0];
+      const found = seed.people.find(
+        (candidate) => candidate.name === username,
+      );
+      return found ? { json: build.userResponse(person(found)) } : notFound;
+    });
   }
 }
 

--- a/src/testing/piefed/index.ts
+++ b/src/testing/piefed/index.ts
@@ -153,15 +153,25 @@ export class FakePiefedInstance extends FakeInstance {
         published: subject.published,
       });
 
-    const notFound = { json: { error: "not_found" }, status: 404 } as const;
+    // Seed misses render through PieFed's real error wire shape (unlike the
+    // deliberate loud 404 for entirely unmocked routes)
+    const notFound = {
+      json: { code: 404, message: "not_found", status: "Not Found" },
+      status: 404,
+    } as const;
 
     this.mock("GET /api/alpha/site", () => ({
       json: build.getSiteResponse({ name: seed.siteName }),
     }));
 
-    this.mock("GET /api/alpha/post/list", () => ({
-      json: build.postListResponse(seed.posts.map(postView)),
-    }));
+    this.mock("GET /api/alpha/post/list", (call) => {
+      // The piefed adapter implements listPersonContent via person_id here
+      const personId = call.query.get("person_id");
+      const posts = personId
+        ? seed.posts.filter((post) => post.creator.id === Number(personId))
+        : seed.posts;
+      return { json: build.postListResponse(posts.map(postView)) };
+    });
 
     this.mock("GET /api/alpha/post", (call) => {
       const post = seed.posts.find(
@@ -172,9 +182,17 @@ export class FakePiefedInstance extends FakeInstance {
 
     this.mock("GET /api/alpha/comment/list", (call) => {
       const postId = call.query.get("post_id");
-      const comments = postId
-        ? seed.comments.filter((comment) => comment.post.id === Number(postId))
-        : seed.comments;
+      // The piefed adapter implements listPersonContent via person_id here
+      const personId = call.query.get("person_id");
+      let comments = seed.comments;
+      if (postId)
+        comments = comments.filter(
+          (comment) => comment.post.id === Number(postId),
+        );
+      if (personId)
+        comments = comments.filter(
+          (comment) => comment.creator.id === Number(personId),
+        );
       return { json: build.commentListResponse(comments.map(commentView)) };
     });
 
@@ -187,6 +205,23 @@ export class FakePiefedInstance extends FakeInstance {
         ? { json: build.communityResponse({ community: community(found) }) }
         : notFound;
     });
+
+    this.mock("GET /api/alpha/user/unread_count", () => ({
+      json: {
+        mentions: seed.notifications.filter(
+          (notification) =>
+            notification.kind === "mention" && !notification.read,
+        ).length,
+        other: 0,
+        private_messages: seed.notifications.filter(
+          (notification) =>
+            notification.kind === "private_message" && !notification.read,
+        ).length,
+        replies: seed.notifications.filter(
+          (notification) => notification.kind === "reply" && !notification.read,
+        ).length,
+      },
+    }));
 
     this.mock("GET /api/alpha/user", (call) => {
       const username = call.query.get("username")?.split("@")[0];

--- a/src/testing/piefed/index.ts
+++ b/src/testing/piefed/index.ts
@@ -1,4 +1,4 @@
-import { FakeInstance } from "../FakeInstance";
+import { FakeInstance, Matcher, OperationApi } from "../FakeInstance";
 import {
   SeedComment,
   SeedCommunity,
@@ -11,6 +11,46 @@ import {
   DEFAULT_PIEFED_VERSION,
   PiefedBuilders,
 } from "./builders";
+
+/**
+ * Operation → route map (threadiverse `BaseClient` endpoint names; routes
+ * from the piefed adapter). Powers `on`/`once`/`callsTo`.
+ */
+const PIEFED_ROUTES = {
+  createComment: "POST /api/alpha/comment",
+  createPost: "POST /api/alpha/post",
+  createPrivateMessage: "POST /api/alpha/private_message",
+  deleteComment: "POST /api/alpha/comment/delete",
+  deletePost: "POST /api/alpha/post/delete",
+  editComment: "PUT /api/alpha/comment",
+  editPost: "PUT /api/alpha/post",
+  followCommunity: "POST /api/alpha/community/follow",
+  getComments: "GET /api/alpha/comment/list",
+  getCommunity: "GET /api/alpha/community",
+  getPersonDetails: "GET /api/alpha/user",
+  getPost: "GET /api/alpha/post",
+  getPosts: "GET /api/alpha/post/list",
+  getSite: "GET /api/alpha/site",
+  getUnreadCount: "GET /api/alpha/user/unread_count",
+  likeComment: "POST /api/alpha/comment/like",
+  likePost: "POST /api/alpha/post/like",
+  login: "POST /api/alpha/user/login",
+  markPostAsRead: "POST /api/alpha/post/mark_as_read",
+  resolveObject: "GET /api/alpha/resolve_object",
+  saveComment: "PUT /api/alpha/comment/save",
+  savePost: "PUT /api/alpha/post/save",
+  search: "GET /api/alpha/search",
+} satisfies Record<string, Matcher>;
+
+export type PiefedOperation = keyof typeof PIEFED_ROUTES;
+
+const STATUS_TEXT: Record<number, string> = {
+  400: "Bad Request",
+  401: "Unauthorized",
+  403: "Forbidden",
+  404: "Not Found",
+  429: "Too Many Requests",
+};
 
 export interface FakePiefedInstanceOptions {
   /** Bare hostname (no scheme) the fake instance answers for */
@@ -39,8 +79,20 @@ export class FakePiefedInstance extends FakeInstance {
   /** Wire-format builders bound to this instance's host */
   readonly build: PiefedBuilders;
 
+  /** Recorded requests for an operation (by name, not route) */
+  readonly callsTo: OperationApi<PiefedOperation>["callsTo"];
+
+  /** Override an operation's response (canonical `{ error }` supported) */
+  readonly on: OperationApi<PiefedOperation>["on"];
+
+  /** Override an operation's next response only, then fall back */
+  readonly once: OperationApi<PiefedOperation>["once"];
+
   /** Semantic content store the default routes are derived from */
   readonly seed = new SeedStore();
+
+  /** Wait until a request for an operation is recorded */
+  readonly waitForCallTo: OperationApi<PiefedOperation>["waitForCallTo"];
 
   constructor({
     host = "piefed.test",
@@ -51,6 +103,22 @@ export class FakePiefedInstance extends FakeInstance {
     const build = createPiefedBuilders({ host, version });
     this.build = build;
     const seed = this.seed;
+
+    const api = this.buildOperationApi(PIEFED_ROUTES, (error) => {
+      const status = error.status ?? 400;
+      return {
+        json: {
+          code: status,
+          message: error.code,
+          status: STATUS_TEXT[status] ?? "Error",
+        },
+        status,
+      };
+    });
+    this.callsTo = api.callsTo;
+    this.on = api.on;
+    this.once = api.once;
+    this.waitForCallTo = api.waitForCallTo;
 
     // seed → wire
     const person = (subject: SeedPerson) =>

--- a/src/testing/seed.ts
+++ b/src/testing/seed.ts
@@ -1,0 +1,250 @@
+/**
+ * Semantic, provider-agnostic seed model for fake instances.
+ *
+ * Consumer tests describe *what exists* — people, posts, comments,
+ * notifications — and each fake instance derives its provider's wire
+ * responses from this store. Specs never touch endpoint paths or wire
+ * shapes for content; `mock()`/`calls()` remain for error injection and
+ * asserting outgoing requests.
+ *
+ * Field names follow threadiverse's canonical types (`post.name`,
+ * `comment.content`) so tests assert on the same names they seed.
+ */
+
+export interface SeedComment {
+  childCount: number;
+  content: string;
+  creator: SeedPerson;
+  id: number;
+  path: string;
+  post: SeedPost;
+  /** ISO 8601; defaults to the fake's fixed "now" */
+  published?: string;
+}
+
+export interface SeedCommunity {
+  id: number;
+  name: string;
+  title: string;
+}
+
+export type SeedNotification =
+  | {
+      comment: SeedComment;
+      id: number;
+      kind: "mention" | "reply";
+      read: boolean;
+    }
+  | {
+      id: number;
+      kind: "private_message";
+      message: SeedPrivateMessage;
+      read: boolean;
+    };
+
+export interface SeedPerson {
+  displayName?: string;
+  id: number;
+  name: string;
+}
+
+export interface SeedPost {
+  body?: string;
+  community: SeedCommunity;
+  creator: SeedPerson;
+  id: number;
+  name: string;
+  url?: string;
+}
+
+export interface SeedPrivateMessage {
+  content: string;
+  creator: SeedPerson;
+  id: number;
+  recipient: SeedPerson;
+}
+
+export class SeedStore {
+  comments: SeedComment[] = [];
+  communities: SeedCommunity[] = [];
+  loggedInPerson: SeedPerson | undefined;
+  notifications: SeedNotification[] = [];
+  people: SeedPerson[] = [];
+  posts: SeedPost[] = [];
+  siteName = "Test site";
+
+  // High start so explicit ids in tests never collide with generated ones
+  #nextId = 1000;
+
+  /** Comments on the given post (in seed order) */
+  commentsFor(post: SeedPost): SeedComment[] {
+    return this.comments.filter((comment) => comment.post === post);
+  }
+
+  comment(over: {
+    childCount?: number;
+    content: string;
+    creator?: SeedPerson;
+    id?: number;
+    path?: string;
+    post?: SeedPost;
+    published?: string;
+  }): SeedComment {
+    const post = over.post ?? this.posts[0] ?? this.post({ name: "Seed post" });
+    const id = over.id ?? this.#nextId++;
+
+    const comment: SeedComment = {
+      childCount: over.childCount ?? 0,
+      content: over.content,
+      creator: over.creator ?? post.creator,
+      id,
+      path: over.path ?? `0.${id}`,
+      post,
+      published: over.published,
+    };
+    this.comments.push(comment);
+    return comment;
+  }
+
+  community(
+    over: { id?: number; name?: string; title?: string } = {},
+  ): SeedCommunity {
+    const community: SeedCommunity = {
+      id: over.id ?? this.#nextId++,
+      name: over.name ?? "test_comm",
+      title: over.title ?? "Test Community",
+    };
+    this.communities.push(community);
+    return community;
+  }
+
+  /**
+   * Mark a person as the authenticated user. Fakes derive the account
+   * endpoints (my user, unread counts) from this.
+   */
+  loggedInAs(person: SeedPerson): void {
+    this.loggedInPerson = person;
+  }
+
+  mention(over: {
+    comment: SeedComment;
+    id?: number;
+    read?: boolean;
+  }): SeedNotification {
+    return this.#notify({ ...over, kind: "mention" });
+  }
+
+  person(over: {
+    displayName?: string;
+    id?: number;
+    name: string;
+  }): SeedPerson {
+    const person: SeedPerson = {
+      displayName: over.displayName,
+      id: over.id ?? this.#nextId++,
+      name: over.name,
+    };
+    this.people.push(person);
+    return person;
+  }
+
+  post(over: {
+    body?: string;
+    community?: SeedCommunity;
+    creator?: SeedPerson;
+    id?: number;
+    name: string;
+    url?: string;
+  }): SeedPost {
+    const post: SeedPost = {
+      body: over.body,
+      community: over.community ?? this.#defaultCommunity(),
+      creator: over.creator ?? this.#defaultPerson(),
+      id: over.id ?? this.#nextId++,
+      name: over.name,
+      url: over.url,
+    };
+    this.posts.push(post);
+    return post;
+  }
+
+  /**
+   * A private message to `recipient` (defaults to the logged-in user),
+   * including its inbox notification.
+   */
+  privateMessage(over: {
+    content: string;
+    creator: SeedPerson;
+    id?: number;
+    read?: boolean;
+    recipient?: SeedPerson;
+  }): SeedPrivateMessage {
+    const recipient = over.recipient ?? this.loggedInPerson;
+
+    if (!recipient)
+      throw new Error(
+        "privateMessage: pass a recipient or seed.loggedInAs(person) first",
+      );
+
+    const message: SeedPrivateMessage = {
+      content: over.content,
+      creator: over.creator,
+      id: over.id ?? this.#nextId++,
+      recipient,
+    };
+
+    this.notifications.push({
+      id: this.#nextId++,
+      kind: "private_message",
+      message,
+      read: over.read ?? false,
+    });
+
+    return message;
+  }
+
+  reply(over: {
+    comment: SeedComment;
+    id?: number;
+    read?: boolean;
+  }): SeedNotification {
+    return this.#notify({ ...over, kind: "reply" });
+  }
+
+  site(over: { name: string }): void {
+    this.siteName = over.name;
+  }
+
+  get unreadNotificationCount(): number {
+    return this.notifications.filter((notification) => !notification.read)
+      .length;
+  }
+
+  #defaultCommunity(): SeedCommunity {
+    return this.communities[0] ?? this.community();
+  }
+
+  #defaultPerson(): SeedPerson {
+    return (
+      this.loggedInPerson ??
+      this.people[0] ??
+      this.person({ name: "seed_user" })
+    );
+  }
+
+  #notify(over: {
+    comment: SeedComment;
+    id?: number;
+    kind: "mention" | "reply";
+    read?: boolean;
+  }): SeedNotification {
+    const notification: SeedNotification = {
+      comment: over.comment,
+      id: over.id ?? this.#nextId++,
+      kind: over.kind,
+      read: over.read ?? false,
+    };
+    this.notifications.push(notification);
+    return notification;
+  }
+}

--- a/src/testing/seed.ts
+++ b/src/testing/seed.ts
@@ -73,13 +73,13 @@ export class SeedStore {
   posts: SeedPost[] = [];
   siteName = "Test site";
 
+  get unreadNotificationCount(): number {
+    return this.notifications.filter((notification) => !notification.read)
+      .length;
+  }
+
   // High start so explicit ids in tests never collide with generated ones
   #nextId = 1000;
-
-  /** Comments on the given post (in seed order) */
-  commentsFor(post: SeedPost): SeedComment[] {
-    return this.comments.filter((comment) => comment.post === post);
-  }
 
   comment(over: {
     childCount?: number;
@@ -104,6 +104,11 @@ export class SeedStore {
     };
     this.comments.push(comment);
     return comment;
+  }
+
+  /** Comments on the given post (in seed order) */
+  commentsFor(post: SeedPost): SeedComment[] {
+    return this.comments.filter((comment) => comment.post === post);
   }
 
   community(
@@ -213,11 +218,6 @@ export class SeedStore {
 
   site(over: { name: string }): void {
     this.siteName = over.name;
-  }
-
-  get unreadNotificationCount(): number {
-    return this.notifications.filter((notification) => !notification.read)
-      .length;
   }
 
   #defaultCommunity(): SeedCommunity {

--- a/test/testing-fake-instance.test.ts
+++ b/test/testing-fake-instance.test.ts
@@ -11,6 +11,7 @@ import ThreadiverseClient from "../src/ThreadiverseClient";
 
 function setup() {
   const instance = new FakeLemmyV1Instance({ host: "v1.fake.test" });
+  instance.seed.site({ name: "Test v1 site" });
 
   const alex = instance.build.person({ id: 100, name: "alex" });
   const posts = [
@@ -168,7 +169,7 @@ describe("FakeLemmyV1Instance + ThreadiverseClient round trip", () => {
   it("answers unmocked endpoints with a 404 error", async () => {
     const { client } = setup();
 
-    await expect(client.getUnreadCount()).rejects.toThrow();
+    await expect(client.search({ search_term: "x" })).rejects.toThrow();
   });
 
   it("simulates aborts as network failures", async () => {

--- a/test/testing-fake-piefed.test.ts
+++ b/test/testing-fake-piefed.test.ts
@@ -11,6 +11,7 @@ import ThreadiverseClient from "../src/ThreadiverseClient";
 
 function setup() {
   const instance = new FakePiefedInstance({ host: "piefed.fake.test" });
+  instance.seed.site({ name: "Test piefed site" });
 
   const alex = instance.build.person({ id: 100, user_name: "alex" });
   const posts = [

--- a/test/testing-seed-matrix.test.ts
+++ b/test/testing-seed-matrix.test.ts
@@ -96,6 +96,27 @@ describe.each([
     expect(calls).toHaveLength(1);
     expect(calls[0]!.query.get("limit")).toBe("7");
   });
+
+  it("listPersonContent only returns the person's content", async () => {
+    const { alex, client, fake, post } = setup();
+
+    const bob = fake.seed.person({ name: "bob" });
+    fake.seed.post({ creator: bob, name: "Bob's post" });
+    fake.seed.comment({ content: "bob's comment", creator: bob, post });
+
+    const { data } = await client.listPersonContent({ person_id: alex.id });
+
+    const names = data.map((item) =>
+      "post" in item && !("comment" in item)
+        ? item.post.name
+        : "comment" in item
+          ? item.comment.content
+          : "?",
+    );
+    expect(names).toContain("Hello **world**");
+    expect(names).not.toContain("Bob's post");
+    expect(names).not.toContain("bob's comment");
+  });
 });
 
 describe("seeded notifications (lemmyv1)", () => {
@@ -128,5 +149,10 @@ describe("seeded notifications (lemmyv1)", () => {
       "reply",
       "private_message",
     ]);
+
+    const { data: unreadOnly } = await client.getNotifications({
+      unread_only: true,
+    });
+    expect(unreadOnly.map((view) => view.notification.kind)).toEqual(["reply"]);
   });
 });

--- a/test/testing-seed-matrix.test.ts
+++ b/test/testing-seed-matrix.test.ts
@@ -1,0 +1,132 @@
+// The provider-matrix contract: one semantic seed scenario, asserted
+// through a real ThreadiverseClient against every fake. Also covers the
+// operation layer (on/once/callsTo) including canonical error injection —
+// the same spec text works for every provider because operations are named
+// after threadiverse endpoints, not routes.
+
+import { describe, expect, it } from "vitest";
+
+import { NotFoundError, RateLimitedError } from "../src/errors";
+import {
+  FakeLemmyV1Instance,
+  FakePiefedInstance,
+  SeedStore,
+} from "../src/testing";
+import ThreadiverseClient from "../src/ThreadiverseClient";
+
+function seedScenario(seed: SeedStore) {
+  const alex = seed.person({ displayName: "Alex", name: "alex" });
+  const cats = seed.community({ name: "cats", title: "Cats" });
+  const post = seed.post({
+    body: "look at this **cat**",
+    community: cats,
+    creator: alex,
+    name: "Hello **world**",
+  });
+  seed.comment({ content: "First!", post });
+  seed.site({ name: "Fake instance" });
+
+  return { alex, cats, post };
+}
+
+describe.each([
+  ["lemmyv1", () => new FakeLemmyV1Instance()],
+  ["piefed", () => new FakePiefedInstance()],
+] as const)("%s", (mode, makeFake) => {
+  function setup() {
+    const fake = makeFake();
+    const scenario = seedScenario(fake.seed);
+    const client = new ThreadiverseClient(fake.origin, fake.clientOptions());
+    return { client, fake, ...scenario };
+  }
+
+  it("serves one seeded scenario consistently across endpoints", async () => {
+    const { client, post } = setup();
+
+    expect((await client.connect()).mode).toBe(mode);
+
+    const site = await client.getSite();
+    expect(site.site_view.site.name).toBe("Fake instance");
+
+    const { data: posts } = await client.getPosts({});
+    expect(posts.map((view) => view.post.name)).toEqual(["Hello **world**"]);
+    expect(posts[0]!.community.name).toBe("cats");
+    expect(posts[0]!.creator.name).toBe("alex");
+
+    const { post_view } = await client.getPost({ id: post.id });
+    expect(post_view.post.name).toBe("Hello **world**");
+
+    const { data: comments } = await client.getComments({ post_id: post.id });
+    expect(comments.map((view) => view.comment.content)).toEqual(["First!"]);
+
+    const { community_view } = await client.getCommunity({ name: "cats" });
+    expect(community_view.community.title).toBe("Cats");
+
+    const { person_view } = await client.getPersonDetails({
+      username: "alex",
+    });
+    expect(person_view.person.name).toBe("alex");
+  });
+
+  it("injects canonical errors that surface as condition classes", async () => {
+    const { client, fake } = setup();
+
+    fake.on.getSite({ error: { code: "rate_limit_error", status: 429 } });
+
+    await expect(client.getSite()).rejects.toBeInstanceOf(RateLimitedError);
+  });
+
+  it("once() overrides a single response, then falls back to seed", async () => {
+    const { client, fake } = setup();
+
+    fake.once.getPosts({ error: { code: "not_found", status: 404 } });
+
+    await expect(client.getPosts({})).rejects.toBeInstanceOf(NotFoundError);
+
+    const { data } = await client.getPosts({});
+    expect(data).toHaveLength(1);
+  });
+
+  it("records calls by operation name", async () => {
+    const { client, fake } = setup();
+
+    await client.getPosts({ limit: 7 });
+
+    const calls = fake.callsTo("getPosts");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.query.get("limit")).toBe("7");
+  });
+});
+
+describe("seeded notifications (lemmyv1)", () => {
+  it("derives inbox endpoints from seeded notifications", async () => {
+    const fake = new FakeLemmyV1Instance();
+    const seed = fake.seed;
+
+    const alex = seed.person({ name: "alex" });
+    const other = seed.person({ name: "other" });
+    seed.loggedInAs(alex);
+
+    const post = seed.post({ creator: alex, name: "A post" });
+    const reply = seed.comment({
+      content: "replying to you",
+      creator: other,
+      post,
+    });
+    seed.reply({ comment: reply });
+    seed.privateMessage({ content: "psst", creator: other, read: true });
+
+    const client = new ThreadiverseClient(fake.origin, fake.clientOptions());
+
+    // v1 reports one combined notification_count; the adapter maps it to
+    // canonical `replies`
+    const unread = await client.getUnreadCount();
+    expect(unread.replies).toBe(1);
+
+    const { data } = await client.getNotifications({});
+    expect(data.map((view) => view.notification.kind)).toEqual([
+      "reply",
+      "private_message",
+    ]);
+  });
+});


### PR DESCRIPTION
Implements the layered API from the design workshop (see `docs/testing-plan.md`, included):

| Layer | API | Use |
| --- | --- | --- |
| Content | `fake.seed.*` | people/communities/posts/comments/notifications/logged-in user; all default routes derived per request, so list/detail/counts stay consistent |
| Behavior | `fake.on.*` / `fake.once.*` | operation-name-keyed overrides (provider-agnostic); canonical `{ error: { code, status } }` renders to each provider's error wire and surfaces as #53's condition classes; `once` = one-shot then fallback |
| Escape hatch | `mock()` / `mockOnce()` | route level |

Plus `callsTo("likePost")` / `waitForCallTo(...)` for operation-keyed request assertions. Operation→route maps verified against lemmy-js-client-v1's route table and the piefed adapter.

The provider-matrix contract test is the headline: **one seeded scenario asserted through a real `ThreadiverseClient` against both fakes**, including cross-provider error-class injection — the shape Voyager's provider-matrix e2e will take.

Next per the plan doc: live fidelity suite (fake responses — especially errors — verified against real instances), then the Voyager adoption branch.

374 tests, lint/typecheck/build green.