### PR TITLE
feat!: remove deprecated APIs

### DIFF
--- a/src/ThreadiverseClient.ts
+++ b/src/ThreadiverseClient.ts
@@ -137,16 +137,6 @@ class ThreadiverseClient {
     return { mode: this.mode, software: this.software };
   }
 
-  /** @deprecated Use `connect()` (or the sync `mode` getter once connected) */
-  async getMode(): Promise<ThreadiverseMode> {
-    return (await this.connect()).mode;
-  }
-
-  /** @deprecated Use `connect()` (or the sync `software` getter once connected) */
-  async getSoftware(): Promise<ProviderInfo> {
-    return (await this.connect()).software;
-  }
-
   private async ensureClient(): Promise<BaseClient> {
     if (this.delegateClient) {
       return this.delegateClient;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -136,34 +136,11 @@ export class InvalidPayloadError extends FediverseError {
   }
 }
 
-/**
- * @deprecated Branch on the condition subclasses (`NotFoundError`, ...) or
- * `error.software` instead. No longer thrown; retained for compatibility.
- */
-export class LemmyResponseError extends ResponseError {
-  constructor(code: string, options?: ResponseErrorOptions) {
-    super(code, { ...options, software: "lemmy" });
-    this.name = "LemmyResponseError";
-  }
-}
-
 /** The requested entity (post, comment, community, person...) doesn't exist */
 export class NotFoundError extends ResponseError {
   constructor(code: string, options?: ResponseErrorOptions) {
     super(code, options);
     this.name = "NotFoundError";
-  }
-}
-
-/**
- * @deprecated Branch on the condition subclasses (`NotFoundError`, ...) or
- * `error.software` instead (raw payload is on `error.response`). No longer
- * thrown; retained for compatibility.
- */
-export class PiefedResponseError extends ResponseError {
-  constructor(code: string, options?: ResponseErrorOptions) {
-    super(code, { ...options, software: "piefed" });
-    this.name = "PiefedResponseError";
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,15 +36,6 @@ export type Instance = z.infer<typeof schemas.Instance>;
 export type InstanceWithFederationState = z.infer<
   typeof schemas.InstanceWithFederationState
 >;
-/**
- * @deprecated Leaks lemmy-js-client-v0's type into the public API; use
- * `ResponseErrorCode` (+ `isErrorCode`) from the package root instead.
- * Will be removed in a future release.
- *
- * (Declared as an alias rather than a re-export so the deprecation JSDoc
- * survives dts bundling.)
- */
-export type LemmyErrorType = import("lemmy-js-client-v0").LemmyErrorType;
 export type LinkMetadata = z.infer<typeof schemas.LinkMetadata>;
 export type ListCommentReportsResponse = z.infer<
   typeof schemas.ListCommentReportsResponse

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -4,7 +4,6 @@ import {
   createResponseError,
   IncorrectLoginError,
   isErrorCode,
-  LemmyResponseError,
   NotFoundError,
   RateLimitedError,
   ResponseError,
@@ -61,10 +60,10 @@ describe("isErrorCode", () => {
     expect(isErrorCode(error, "too_many_requests")).toBe(false);
   });
 
-  it("matches subclasses by code", () => {
+  it("matches condition subclasses by code", () => {
     expect(
       isErrorCode(
-        new LemmyResponseError("rate_limit_error"),
+        createResponseError("rate_limit_error", { software: "lemmy" }),
         "rate_limit_error",
       ),
     ).toBe(true);

--- a/test/live-smoke.test.ts
+++ b/test/live-smoke.test.ts
@@ -33,7 +33,7 @@ describe.runIf(process.env.LIVE_SMOKE)("live smoke", () => {
     });
 
     it("discovers software", OPTIONS, async () => {
-      expect((await client.getSoftware()).name).toBe(software);
+      expect((await client.connect()).software.name).toBe(software);
     });
 
     it("getSite passes canonical validation", OPTIONS, async () => {

--- a/test/testing-fake-instance.test.ts
+++ b/test/testing-fake-instance.test.ts
@@ -44,10 +44,9 @@ describe("FakeLemmyV1Instance + ThreadiverseClient round trip", () => {
   it("discovers software via nodeinfo", async () => {
     const { client } = setup();
 
-    expect(await client.getMode()).toBe("lemmyv1");
-    expect(await client.getSoftware()).toEqual({
-      name: "lemmy",
-      version: "1.0.0-beta.1",
+    expect(await client.connect()).toEqual({
+      mode: "lemmyv1",
+      software: { name: "lemmy", version: "1.0.0-beta.1" },
     });
   });
 
@@ -202,8 +201,8 @@ describe("FakeLemmyV1Instance + ThreadiverseClient round trip", () => {
       second.clientOptions(),
     );
 
-    expect((await firstClient.getSoftware()).version).toBe("1.0.0-beta.1");
-    expect((await secondClient.getSoftware()).version).toBe("1.2.0");
+    expect((await firstClient.connect()).software.version).toBe("1.0.0-beta.1");
+    expect((await secondClient.connect()).software.version).toBe("1.2.0");
   });
 
   it("serves null-body statuses through the fetch adapter", async () => {


### PR DESCRIPTION
Per policy: this is a v0 library — no deprecation shims. Deletes `LemmyResponseError`/`PiefedResponseError` (replaced by condition subclasses + `error.software`, #53), the `LemmyErrorType` re-export (replaced by `ResponseErrorCode`, #50), and `getMode()`/`getSoftware()` (replaced by `connect()` + sync getters, #51). In-repo usages migrated; Voyager's call sites move on its adoption branch. 376 tests, lint/typecheck/build green; dist exports verified free of the removed symbols.