### PR TITLE
feat: Missing2faError condition

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -105,7 +105,7 @@ export class EmailNotVerifiedError extends ResponseError {
   }
 }
 
-/** Wrong or missing TOTP second factor */
+/** Wrong TOTP second factor */
 export class Incorrect2faError extends ResponseError {
   constructor(code: string, options?: ResponseErrorOptions) {
     super(code, options);
@@ -133,6 +133,17 @@ export class InvalidPayloadError extends FediverseError {
   constructor(message: string) {
     super(message);
     this.name = "InvalidPayloadError";
+  }
+}
+
+/**
+ * A TOTP second factor is required but wasn't provided (e.g. show the 2FA
+ * input on the login form)
+ */
+export class Missing2faError extends ResponseError {
+  constructor(code: string, options?: ResponseErrorOptions) {
+    super(code, options);
+    this.name = "Missing2faError";
   }
 }
 
@@ -193,6 +204,7 @@ const CONDITION_BY_CODE: Record<string, ResponseErrorConstructor> = {
   incorrect_login: IncorrectLoginError,
   incorrect_totp_token: Incorrect2faError,
   invalid_bot_action: InvalidBotActionError,
+  missing_totp_token: Missing2faError,
   "No row was found when one was required": NotFoundError,
   not_found: NotFoundError,
   rate_limit_error: RateLimitedError,

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   createResponseError,
+  Incorrect2faError,
   IncorrectLoginError,
   isErrorCode,
+  Missing2faError,
   NotFoundError,
   RateLimitedError,
   ResponseError,
@@ -23,6 +25,15 @@ describe("createResponseError", () => {
     expect(error.message).toBe("incorrect_login");
     expect(error.software).toBe("lemmy");
     expect(error.status).toBe(401);
+  });
+
+  it("distinguishes missing vs incorrect 2fa", () => {
+    expect(createResponseError("missing_totp_token")).toBeInstanceOf(
+      Missing2faError,
+    );
+    expect(createResponseError("incorrect_totp_token")).toBeInstanceOf(
+      Incorrect2faError,
+    );
   });
 
   it("maps equivalent codes across versions to one condition", () => {


### PR DESCRIPTION
Voyager's login flow branches on `missing_totp_token` (to reveal the 2FA input) — per the taxonomy rule, consumer-branched conditions get classes. Distinct from Incorrect2faError (wrong code vs no code). Trivial mapping + test.