### PR TITLE
feat: map PieFed 'No object found.' to NotFoundError

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -205,6 +205,7 @@ const CONDITION_BY_CODE: Record<string, ResponseErrorConstructor> = {
   incorrect_totp_token: Incorrect2faError,
   invalid_bot_action: InvalidBotActionError,
   missing_totp_token: Missing2faError,
+  "No object found.": NotFoundError,
   "No row was found when one was required": NotFoundError,
   not_found: NotFoundError,
   rate_limit_error: RateLimitedError,

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -50,6 +50,10 @@ describe("createResponseError", () => {
       NotFoundError,
     );
     expect(createResponseError("not_found")).toBeInstanceOf(NotFoundError);
+    // PieFed's resolve_object miss
+    expect(createResponseError("No object found.")).toBeInstanceOf(
+      NotFoundError,
+    );
   });
 
   it("falls back to the base class for unmapped codes", () => {


### PR DESCRIPTION
PieFed's resolve_object miss message, observed in production (Voyager's resolveSlice hand-matched the string). Lets Voyager's isNotFoundError helper collapse to `instanceof NotFoundError`.