### PR TITLE
feat(testing): canonical request decoders (callsTo/waitForPayload)

### DIFF
--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -21,7 +21,7 @@ type-checked against the same upstream types the compat layers consume, and
 | Behavior     | `fake.on.*` / `fake.once.*`     | Per-operation overrides keyed by threadiverse endpoint name (provider-agnostic): error injection (canonical `{ code, status }`), custom wire responses (typed via `fake.build.*`), one-shot sequencing. |
 | Escape hatch | `fake.mock(matcher, responder)` | Anything else, at the HTTP route level. Discouraged in consumer specs.                                                                                                                                  |
 
-Request assertions: `fake.callsTo("likePost")` / `fake.waitForCallTo(...)` —
+Request assertions: `fake.callsTo("likePost")` / `fake.waitForPayload(...)` —
 operation-keyed views over the existing recording.
 
 ```ts

--- a/src/testing/FakeInstance.ts
+++ b/src/testing/FakeInstance.ts
@@ -48,19 +48,38 @@ export type FakeResponse =
 /** `"METHOD /path"` — matched against pathname only (query ignored) */
 export type Matcher = `${"DELETE" | "GET" | "POST" | "PUT"} /${string}`;
 
-export interface OperationApi<Operation extends string> {
-  /** Recorded requests for an operation (by name, not route) */
-  callsTo(operation: Operation): RecordedCall[];
-  /** Override an operation's response. Last call wins. */
-  on: Record<Operation, (responder: OperationResponder) => void>;
-  /** Override an operation's next response only, then fall back. */
-  once: Record<Operation, (responder: OperationResponder) => void>;
-  /** Wait until a request for an operation is recorded. */
-  waitForCallTo(
+export interface OperationApi<Ops extends Record<string, OperationDef>> {
+  /**
+   * Canonical payloads of the requests an operation received (in order).
+   * Only operations with a decoder; use `calls()` for wire-level access.
+   */
+  callsTo<Operation extends DecodableOperation<Ops>>(
     operation: Operation,
-    predicate?: (call: RecordedCall) => boolean,
+  ): PayloadOf<Ops[Operation]>[];
+  /** Override an operation's response. Last call wins. */
+  on: { [Operation in keyof Ops]: (responder: OperationResponder) => void };
+  /** Override an operation's next response only, then fall back. */
+  once: { [Operation in keyof Ops]: (responder: OperationResponder) => void };
+  /**
+   * Wait until an operation receives a request, then return its canonical
+   * payload.
+   */
+  waitForPayload<Operation extends DecodableOperation<Ops>>(
+    operation: Operation,
+    predicate?: (payload: PayloadOf<Ops[Operation]>) => boolean,
     options?: { timeoutMs?: number },
-  ): Promise<RecordedCall>;
+  ): Promise<PayloadOf<Ops[Operation]>>;
+}
+
+export interface OperationDef<Payload = unknown> {
+  /**
+   * Reconstruct the canonical threadiverse payload from the wire request,
+   * so consumer tests assert on what their app *meant* — never on routes,
+   * query params, or wire body shapes. Partial where the wire is lossy.
+   * Round-trip tested against the real client in threadiverse.
+   */
+  decode?: (call: RecordedCall) => Payload;
+  route: Matcher;
 }
 
 export type OperationResponder =
@@ -80,6 +99,15 @@ export type RecordedCall = {
 export type Responder =
   | ((call: RecordedCall) => FakeResponse | Promise<FakeResponse>)
   | FakeResponse;
+
+type DecodableOperation<Ops extends Record<string, OperationDef>> = {
+  [K in keyof Ops]: Ops[K]["decode"] extends (call: RecordedCall) => unknown
+    ? K
+    : never;
+}[keyof Ops];
+
+type PayloadOf<Def extends OperationDef> =
+  Def extends OperationDef<infer Payload> ? Payload : never;
 
 /** Response statuses that must not carry a body (fetch `Response` throws) */
 const NULL_BODY_STATUSES = [204, 205, 304];
@@ -334,13 +362,13 @@ export class FakeInstance {
   }
 
   /**
-   * Build the operation-level API (`on`/`once`/`callsTo`/`waitForCallTo`)
-   * from a provider's operation → route map plus its error wire renderer.
+   * Build the operation-level API (`on`/`once`/`callsTo`/`waitForPayload`)
+   * from a provider's operation definitions plus its error wire renderer.
    */
-  protected buildOperationApi<Operation extends string>(
-    routes: Record<Operation, Matcher>,
+  protected buildOperationApi<Ops extends Record<string, OperationDef>>(
+    operations: Ops,
     renderError: (error: ErrorInjection) => FakeResponse,
-  ): OperationApi<Operation> {
+  ): OperationApi<Ops> {
     const toResponder = (responder: OperationResponder): Responder => {
       const render = (response: OperationResponse): FakeResponse =>
         "error" in response ? renderError(response.error) : response;
@@ -350,22 +378,43 @@ export class FakeInstance {
         : render(responder);
     };
 
-    const on = {} as OperationApi<Operation>["on"];
-    const once = {} as OperationApi<Operation>["once"];
+    const on = {} as OperationApi<Ops>["on"];
+    const once = {} as OperationApi<Ops>["once"];
 
-    for (const operation of Object.keys(routes) as Operation[]) {
+    for (const operation of Object.keys(operations) as (keyof Ops)[]) {
       on[operation] = (responder) =>
-        this.mock(routes[operation], toResponder(responder));
+        this.mock(operations[operation]!.route, toResponder(responder));
       once[operation] = (responder) =>
-        this.mockOnce(routes[operation], toResponder(responder));
+        this.mockOnce(operations[operation]!.route, toResponder(responder));
     }
 
+    const decoderFor = (operation: keyof Ops) => {
+      const decode = operations[operation]!.decode;
+      if (!decode)
+        throw new Error(
+          `${String(operation)} has no payload decoder — use calls() for wire-level access`,
+        );
+      return decode;
+    };
+
     return {
-      callsTo: (operation) => this.calls(routes[operation]),
+      callsTo: (operation) => {
+        const decode = decoderFor(operation);
+        return this.calls(operations[operation]!.route).map(
+          (call) => decode(call) as never,
+        );
+      },
       on,
       once,
-      waitForCallTo: (operation, predicate, options) =>
-        this.waitForCall(routes[operation], predicate, options),
+      waitForPayload: async (operation, predicate, options) => {
+        const decode = decoderFor(operation);
+        const call = await this.waitForCall(
+          operations[operation]!.route,
+          predicate ? (call) => predicate(decode(call) as never) : undefined,
+          options,
+        );
+        return decode(call) as never;
+      },
     };
   }
 

--- a/src/testing/lemmyv1/index.ts
+++ b/src/testing/lemmyv1/index.ts
@@ -117,7 +117,8 @@ const LEMMY_V1_OPERATIONS = {
       return {
         community_name: q.community_name,
         limit: numberish(q.limit),
-        type_: q.type_?.toLowerCase() as Payload<"getPosts">["type_"],
+        // v1 wire listing types are already canonical lowercase
+        type_: q.type_ as Payload<"getPosts">["type_"],
       };
     },
     route: "GET /api/v4/post/list",
@@ -169,12 +170,15 @@ const LEMMY_V1_OPERATIONS = {
       return {
         limit: numberish(q.limit),
         search_term: q.search_term,
-        type_: q.type_?.toLowerCase() as Payload<"search">["type_"],
+        // v1 wire search types are already canonical lowercase
+        type_: q.type_ as Payload<"search">["type_"],
       };
     },
     route: "GET /api/v4/search",
   },
-} satisfies Record<string, OperationDef>;
+} satisfies {
+  [K in keyof BaseClient]?: OperationDef<Partial<Parameters<BaseClient[K]>[0]>>;
+};
 
 export interface FakeLemmyV1InstanceOptions {
   /** Bare hostname (no scheme) the fake instance answers for */

--- a/src/testing/lemmyv1/index.ts
+++ b/src/testing/lemmyv1/index.ts
@@ -1,4 +1,11 @@
-import { FakeInstance, Matcher, OperationApi } from "../FakeInstance";
+import type { BaseClient } from "../../BaseClient";
+
+import {
+  FakeInstance,
+  OperationApi,
+  OperationDef,
+  RecordedCall,
+} from "../FakeInstance";
 import {
   SeedComment,
   SeedCommunity,
@@ -14,40 +21,160 @@ import {
 } from "./builders";
 
 /**
- * Operation → route map (threadiverse `BaseClient` endpoint names; routes
- * verified against lemmy-js-client-v1). Powers `on`/`once`/`callsTo`.
+ * Canonical payload shape for a threadiverse endpoint (partial: some wire
+ * requests are lossy, e.g. v1 drops `kind` from markNotificationAsRead).
  */
-const LEMMY_V1_ROUTES = {
-  createComment: "POST /api/v4/comment",
-  createPost: "POST /api/v4/post",
-  createPrivateMessage: "POST /api/v4/private_message",
-  deleteComment: "DELETE /api/v4/comment",
-  deletePost: "DELETE /api/v4/post",
-  editComment: "PUT /api/v4/comment",
-  editPost: "PUT /api/v4/post",
-  followCommunity: "POST /api/v4/community/follow",
-  getComments: "GET /api/v4/comment/list",
-  getCommunity: "GET /api/v4/community",
-  getModlog: "GET /api/v4/modlog",
-  getNotifications: "GET /api/v4/account/notification/list",
-  getPersonDetails: "GET /api/v4/person",
-  getPost: "GET /api/v4/post",
-  getPosts: "GET /api/v4/post/list",
-  getRandomCommunity: "GET /api/v4/community/random",
-  getSite: "GET /api/v4/site",
-  getSiteMetadata: "GET /api/v4/post/site_metadata",
-  getUnreadCount: "GET /api/v4/account/unread_counts",
-  likeComment: "POST /api/v4/comment/like",
-  likePost: "POST /api/v4/post/like",
-  listPersonContent: "GET /api/v4/person/content",
-  login: "POST /api/v4/account/auth/login",
-  markNotificationAsRead: "POST /api/v4/account/notification/mark_as_read",
-  markPostAsRead: "POST /api/v4/post/mark_as_read/many",
-  resolveObject: "GET /api/v4/resolve_object",
-  saveComment: "PUT /api/v4/comment/save",
-  savePost: "PUT /api/v4/post/save",
-  search: "GET /api/v4/search",
-} satisfies Record<string, Matcher>;
+type Payload<K extends keyof BaseClient> = Partial<
+  Parameters<BaseClient[K]>[0]
+>;
+
+/** v1 request bodies are canonical passthrough for most write endpoints */
+const body =
+  <K extends keyof BaseClient>() =>
+  (call: RecordedCall) =>
+    call.body as Payload<K>;
+
+function numberish(value: string | undefined): number | undefined {
+  return value === undefined ? undefined : Number(value);
+}
+
+function query(call: RecordedCall): Record<string, string> {
+  return Object.fromEntries(call.query);
+}
+
+/**
+ * Operation definitions (threadiverse `BaseClient` endpoint names; routes
+ * verified against lemmy-js-client-v1; decoders reconstruct canonical
+ * payloads from the wire, round-trip tested in
+ * test/testing-request-decoders.test.ts). Powers `on`/`once`/`callsTo`/
+ * `waitForPayload`.
+ */
+const LEMMY_V1_OPERATIONS = {
+  createComment: {
+    decode: body<"createComment">(),
+    route: "POST /api/v4/comment",
+  },
+  createPost: { decode: body<"createPost">(), route: "POST /api/v4/post" },
+  createPrivateMessage: {
+    decode: body<"createPrivateMessage">(),
+    route: "POST /api/v4/private_message",
+  },
+  deleteComment: {
+    decode: body<"deleteComment">(),
+    route: "DELETE /api/v4/comment",
+  },
+  deletePost: { decode: body<"deletePost">(), route: "DELETE /api/v4/post" },
+  editComment: { decode: body<"editComment">(), route: "PUT /api/v4/comment" },
+  editPost: { decode: body<"editPost">(), route: "PUT /api/v4/post" },
+  followCommunity: {
+    decode: body<"followCommunity">(),
+    route: "POST /api/v4/community/follow",
+  },
+  getComments: {
+    decode: (call: RecordedCall): Payload<"getComments"> => {
+      const q = query(call);
+      return {
+        limit: numberish(q.limit),
+        max_depth: numberish(q.max_depth),
+        post_id: numberish(q.post_id),
+      };
+    },
+    route: "GET /api/v4/comment/list",
+  },
+  getCommunity: {
+    decode: (call: RecordedCall): Payload<"getCommunity"> => ({
+      name: query(call).name,
+    }),
+    route: "GET /api/v4/community",
+  },
+  getModlog: { route: "GET /api/v4/modlog" },
+  getNotifications: {
+    decode: (call: RecordedCall): Payload<"getNotifications"> => {
+      const q = query(call);
+      return {
+        limit: numberish(q.limit),
+        unread_only:
+          q.unread_only === undefined ? undefined : q.unread_only === "true",
+      };
+    },
+    route: "GET /api/v4/account/notification/list",
+  },
+  getPersonDetails: {
+    decode: (call: RecordedCall): Payload<"getPersonDetails"> => ({
+      username: query(call).username,
+    }),
+    route: "GET /api/v4/person",
+  },
+  getPost: {
+    decode: (call: RecordedCall): Payload<"getPost"> => ({
+      id: numberish(query(call).id),
+    }),
+    route: "GET /api/v4/post",
+  },
+  getPosts: {
+    decode: (call: RecordedCall): Payload<"getPosts"> => {
+      const q = query(call);
+      return {
+        community_name: q.community_name,
+        limit: numberish(q.limit),
+        type_: q.type_?.toLowerCase() as Payload<"getPosts">["type_"],
+      };
+    },
+    route: "GET /api/v4/post/list",
+  },
+  getRandomCommunity: { route: "GET /api/v4/community/random" },
+  getSite: { route: "GET /api/v4/site" },
+  getSiteMetadata: {
+    decode: (call: RecordedCall): Payload<"getSiteMetadata"> => ({
+      url: query(call).url,
+    }),
+    route: "GET /api/v4/post/site_metadata",
+  },
+  getUnreadCount: { route: "GET /api/v4/account/unread_counts" },
+  likeComment: {
+    decode: body<"likeComment">(),
+    route: "POST /api/v4/comment/like",
+  },
+  likePost: { decode: body<"likePost">(), route: "POST /api/v4/post/like" },
+  listPersonContent: {
+    decode: (call: RecordedCall): Payload<"listPersonContent"> => ({
+      person_id: numberish(query(call).person_id),
+    }),
+    route: "GET /api/v4/person/content",
+  },
+  login: { decode: body<"login">(), route: "POST /api/v4/account/auth/login" },
+  markNotificationAsRead: {
+    // v1 drops `kind` on the wire — payload is partial
+    decode: body<"markNotificationAsRead">(),
+    route: "POST /api/v4/account/notification/mark_as_read",
+  },
+  markPostAsRead: {
+    decode: body<"markPostAsRead">(),
+    route: "POST /api/v4/post/mark_as_read/many",
+  },
+  resolveObject: {
+    decode: (call: RecordedCall): Payload<"resolveObject"> => ({
+      q: query(call).q,
+    }),
+    route: "GET /api/v4/resolve_object",
+  },
+  saveComment: {
+    decode: body<"saveComment">(),
+    route: "PUT /api/v4/comment/save",
+  },
+  savePost: { decode: body<"savePost">(), route: "PUT /api/v4/post/save" },
+  search: {
+    decode: (call: RecordedCall): Payload<"search"> => {
+      const q = query(call);
+      return {
+        limit: numberish(q.limit),
+        search_term: q.search_term,
+        type_: q.type_?.toLowerCase() as Payload<"search">["type_"],
+      };
+    },
+    route: "GET /api/v4/search",
+  },
+} satisfies Record<string, OperationDef>;
 
 export interface FakeLemmyV1InstanceOptions {
   /** Bare hostname (no scheme) the fake instance answers for */
@@ -56,7 +183,7 @@ export interface FakeLemmyV1InstanceOptions {
   version?: string;
 }
 
-export type LemmyV1Operation = keyof typeof LEMMY_V1_ROUTES;
+export type LemmyV1Operation = keyof typeof LEMMY_V1_OPERATIONS;
 
 /**
  * `FakeInstance` for Lemmy v1 whose default routes are derived, per
@@ -79,20 +206,22 @@ export class FakeLemmyV1Instance extends FakeInstance {
   /** Wire-format builders bound to this instance's host */
   readonly build: LemmyV1Builders;
 
-  /** Recorded requests for an operation (by name, not route) */
-  readonly callsTo: OperationApi<LemmyV1Operation>["callsTo"];
+  /** Canonical payloads of the requests an operation received */
+  readonly callsTo: OperationApi<typeof LEMMY_V1_OPERATIONS>["callsTo"];
 
   /** Override an operation's response (canonical `{ error }` supported) */
-  readonly on: OperationApi<LemmyV1Operation>["on"];
+  readonly on: OperationApi<typeof LEMMY_V1_OPERATIONS>["on"];
 
   /** Override an operation's next response only, then fall back */
-  readonly once: OperationApi<LemmyV1Operation>["once"];
+  readonly once: OperationApi<typeof LEMMY_V1_OPERATIONS>["once"];
 
   /** Semantic content store the default routes are derived from */
   readonly seed = new SeedStore();
 
-  /** Wait until a request for an operation is recorded */
-  readonly waitForCallTo: OperationApi<LemmyV1Operation>["waitForCallTo"];
+  /** Wait for an operation's next request; resolves its canonical payload */
+  readonly waitForPayload: OperationApi<
+    typeof LEMMY_V1_OPERATIONS
+  >["waitForPayload"];
 
   constructor({
     host = "v1.test.lemmy",
@@ -104,14 +233,14 @@ export class FakeLemmyV1Instance extends FakeInstance {
     this.build = build;
     const seed = this.seed;
 
-    const api = this.buildOperationApi(LEMMY_V1_ROUTES, (error) => ({
+    const api = this.buildOperationApi(LEMMY_V1_OPERATIONS, (error) => ({
       json: { error: error.code },
       status: error.status ?? 400,
     }));
     this.callsTo = api.callsTo;
     this.on = api.on;
     this.once = api.once;
-    this.waitForCallTo = api.waitForCallTo;
+    this.waitForPayload = api.waitForPayload;
 
     // seed → wire
     const person = (subject: SeedPerson) =>

--- a/src/testing/piefed/index.ts
+++ b/src/testing/piefed/index.ts
@@ -30,6 +30,14 @@ const body =
   (call: RecordedCall) =>
     call.body as Payload<K>;
 
+// Inverse of compat's fromListingType
+const LISTING_TYPE_FROM_WIRE: Record<string, Payload<"getPosts">["type_"]> = {
+  All: "all",
+  Local: "local",
+  ModeratorView: "moderator_view",
+  Subscribed: "subscribed",
+};
+
 function fromScore(score: number | undefined): boolean | undefined {
   if (score === 1) return true;
   if (score === -1) return false;
@@ -53,16 +61,9 @@ function query(call: RecordedCall): Record<string, string> {
 const PIEFED_OPERATIONS = {
   createComment: {
     decode: (call: RecordedCall): Payload<"createComment"> => {
-      const wire = call.body as {
-        body: string;
-        parent_id?: number;
-        post_id: number;
-      };
-      return {
-        content: wire.body,
-        parent_id: wire.parent_id,
-        post_id: wire.post_id,
-      };
+      // wire = canonical (spread) with content also duplicated as `body`
+      const { body, ...payload } = call.body as { body: string };
+      return { ...payload, content: body };
     },
     route: "POST /api/alpha/comment",
   },
@@ -89,8 +90,9 @@ const PIEFED_OPERATIONS = {
   },
   editComment: {
     decode: (call: RecordedCall): Payload<"editComment"> => {
-      const wire = call.body as { body: string; comment_id: number };
-      return { comment_id: wire.comment_id, content: wire.body };
+      // wire = canonical (spread) with content also duplicated as `body`
+      const { body, ...payload } = call.body as { body: string };
+      return { ...payload, content: body };
     },
     route: "PUT /api/alpha/comment",
   },
@@ -142,7 +144,8 @@ const PIEFED_OPERATIONS = {
       return {
         community_name: q.community_name,
         limit: numberish(q.limit),
-        type_: q.type_?.toLowerCase() as Payload<"getPosts">["type_"],
+        type_:
+          q.type_ === undefined ? undefined : LISTING_TYPE_FROM_WIRE[q.type_],
       };
     },
     route: "GET /api/alpha/post/list",
@@ -196,7 +199,9 @@ const PIEFED_OPERATIONS = {
     },
     route: "GET /api/alpha/search",
   },
-} satisfies Record<string, OperationDef>;
+} satisfies {
+  [K in keyof BaseClient]?: OperationDef<Partial<Parameters<BaseClient[K]>[0]>>;
+};
 
 export type PiefedOperation = keyof typeof PIEFED_OPERATIONS;
 

--- a/src/testing/piefed/index.ts
+++ b/src/testing/piefed/index.ts
@@ -1,4 +1,11 @@
-import { FakeInstance, Matcher, OperationApi } from "../FakeInstance";
+import type { BaseClient } from "../../BaseClient";
+
+import {
+  FakeInstance,
+  OperationApi,
+  OperationDef,
+  RecordedCall,
+} from "../FakeInstance";
 import {
   SeedComment,
   SeedCommunity,
@@ -12,37 +19,186 @@ import {
   PiefedBuilders,
 } from "./builders";
 
-/**
- * Operation → route map (threadiverse `BaseClient` endpoint names; routes
- * from the piefed adapter). Powers `on`/`once`/`callsTo`.
- */
-const PIEFED_ROUTES = {
-  createComment: "POST /api/alpha/comment",
-  createPost: "POST /api/alpha/post",
-  createPrivateMessage: "POST /api/alpha/private_message",
-  deleteComment: "POST /api/alpha/comment/delete",
-  deletePost: "POST /api/alpha/post/delete",
-  editComment: "PUT /api/alpha/comment",
-  editPost: "PUT /api/alpha/post",
-  followCommunity: "POST /api/alpha/community/follow",
-  getComments: "GET /api/alpha/comment/list",
-  getCommunity: "GET /api/alpha/community",
-  getPersonDetails: "GET /api/alpha/user",
-  getPost: "GET /api/alpha/post",
-  getPosts: "GET /api/alpha/post/list",
-  getSite: "GET /api/alpha/site",
-  getUnreadCount: "GET /api/alpha/user/unread_count",
-  likeComment: "POST /api/alpha/comment/like",
-  likePost: "POST /api/alpha/post/like",
-  login: "POST /api/alpha/user/login",
-  markPostAsRead: "POST /api/alpha/post/mark_as_read",
-  resolveObject: "GET /api/alpha/resolve_object",
-  saveComment: "PUT /api/alpha/comment/save",
-  savePost: "PUT /api/alpha/post/save",
-  search: "GET /api/alpha/search",
-} satisfies Record<string, Matcher>;
+/** Canonical payload shape for a threadiverse endpoint (partial) */
+type Payload<K extends keyof BaseClient> = Partial<
+  Parameters<BaseClient[K]>[0]
+>;
 
-export type PiefedOperation = keyof typeof PIEFED_ROUTES;
+/** piefed request bodies that are canonical passthrough */
+const body =
+  <K extends keyof BaseClient>() =>
+  (call: RecordedCall) =>
+    call.body as Payload<K>;
+
+function fromScore(score: number | undefined): boolean | undefined {
+  if (score === 1) return true;
+  if (score === -1) return false;
+  return undefined;
+}
+
+function numberish(value: string | undefined): number | undefined {
+  return value === undefined ? undefined : Number(value);
+}
+
+function query(call: RecordedCall): Record<string, string> {
+  return Object.fromEntries(call.query);
+}
+
+/**
+ * Operation definitions (threadiverse `BaseClient` endpoint names; routes
+ * from the piefed adapter; decoders reconstruct canonical payloads from the
+ * wire, round-trip tested in test/testing-request-decoders.test.ts). Powers
+ * `on`/`once`/`callsTo`/`waitForPayload`.
+ */
+const PIEFED_OPERATIONS = {
+  createComment: {
+    decode: (call: RecordedCall): Payload<"createComment"> => {
+      const wire = call.body as {
+        body: string;
+        parent_id?: number;
+        post_id: number;
+      };
+      return {
+        content: wire.body,
+        parent_id: wire.parent_id,
+        post_id: wire.post_id,
+      };
+    },
+    route: "POST /api/alpha/comment",
+  },
+  createPost: {
+    decode: (call: RecordedCall): Payload<"createPost"> => {
+      // wire = canonical + duplicated `title` field
+      const payload = { ...(call.body as Record<string, unknown>) };
+      delete payload.title;
+      return payload as Payload<"createPost">;
+    },
+    route: "POST /api/alpha/post",
+  },
+  createPrivateMessage: {
+    decode: body<"createPrivateMessage">(),
+    route: "POST /api/alpha/private_message",
+  },
+  deleteComment: {
+    decode: body<"deleteComment">(),
+    route: "POST /api/alpha/comment/delete",
+  },
+  deletePost: {
+    decode: body<"deletePost">(),
+    route: "POST /api/alpha/post/delete",
+  },
+  editComment: {
+    decode: (call: RecordedCall): Payload<"editComment"> => {
+      const wire = call.body as { body: string; comment_id: number };
+      return { comment_id: wire.comment_id, content: wire.body };
+    },
+    route: "PUT /api/alpha/comment",
+  },
+  editPost: {
+    decode: (call: RecordedCall): Payload<"editPost"> => {
+      // wire = canonical + duplicated `title` field
+      const payload = { ...(call.body as Record<string, unknown>) };
+      delete payload.title;
+      return payload as Payload<"editPost">;
+    },
+    route: "PUT /api/alpha/post",
+  },
+  followCommunity: {
+    decode: body<"followCommunity">(),
+    route: "POST /api/alpha/community/follow",
+  },
+  getComments: {
+    decode: (call: RecordedCall): Payload<"getComments"> => {
+      const q = query(call);
+      return {
+        limit: numberish(q.limit),
+        max_depth: numberish(q.max_depth),
+        post_id: numberish(q.post_id),
+      };
+    },
+    route: "GET /api/alpha/comment/list",
+  },
+  getCommunity: {
+    decode: (call: RecordedCall): Payload<"getCommunity"> => ({
+      name: query(call).name,
+    }),
+    route: "GET /api/alpha/community",
+  },
+  getPersonDetails: {
+    decode: (call: RecordedCall): Payload<"getPersonDetails"> => ({
+      username: query(call).username,
+    }),
+    route: "GET /api/alpha/user",
+  },
+  getPost: {
+    decode: (call: RecordedCall): Payload<"getPost"> => ({
+      id: numberish(query(call).id),
+    }),
+    route: "GET /api/alpha/post",
+  },
+  getPosts: {
+    decode: (call: RecordedCall): Payload<"getPosts"> => {
+      const q = query(call);
+      return {
+        community_name: q.community_name,
+        limit: numberish(q.limit),
+        type_: q.type_?.toLowerCase() as Payload<"getPosts">["type_"],
+      };
+    },
+    route: "GET /api/alpha/post/list",
+  },
+  getSite: { route: "GET /api/alpha/site" },
+  getUnreadCount: { route: "GET /api/alpha/user/unread_count" },
+  likeComment: {
+    decode: (call: RecordedCall): Payload<"likeComment"> => {
+      const wire = call.body as { comment_id: number; score?: number };
+      return { comment_id: wire.comment_id, is_upvote: fromScore(wire.score) };
+    },
+    route: "POST /api/alpha/comment/like",
+  },
+  likePost: {
+    decode: (call: RecordedCall): Payload<"likePost"> => {
+      const wire = call.body as { post_id: number; score?: number };
+      return { is_upvote: fromScore(wire.score), post_id: wire.post_id };
+    },
+    route: "POST /api/alpha/post/like",
+  },
+  login: {
+    decode: (call: RecordedCall): Payload<"login"> => {
+      const wire = call.body as { password: string; username: string };
+      return { password: wire.password, username_or_email: wire.username };
+    },
+    route: "POST /api/alpha/user/login",
+  },
+  markPostAsRead: {
+    decode: body<"markPostAsRead">(),
+    route: "POST /api/alpha/post/mark_as_read",
+  },
+  resolveObject: {
+    decode: (call: RecordedCall): Payload<"resolveObject"> => ({
+      q: query(call).q,
+    }),
+    route: "GET /api/alpha/resolve_object",
+  },
+  saveComment: {
+    decode: body<"saveComment">(),
+    route: "PUT /api/alpha/comment/save",
+  },
+  savePost: { decode: body<"savePost">(), route: "PUT /api/alpha/post/save" },
+  search: {
+    decode: (call: RecordedCall): Payload<"search"> => {
+      const q = query(call);
+      return {
+        limit: numberish(q.limit),
+        search_term: q.q,
+        type_: q.type_?.toLowerCase() as Payload<"search">["type_"],
+      };
+    },
+    route: "GET /api/alpha/search",
+  },
+} satisfies Record<string, OperationDef>;
+
+export type PiefedOperation = keyof typeof PIEFED_OPERATIONS;
 
 const STATUS_TEXT: Record<number, string> = {
   400: "Bad Request",
@@ -79,20 +235,22 @@ export class FakePiefedInstance extends FakeInstance {
   /** Wire-format builders bound to this instance's host */
   readonly build: PiefedBuilders;
 
-  /** Recorded requests for an operation (by name, not route) */
-  readonly callsTo: OperationApi<PiefedOperation>["callsTo"];
+  /** Canonical payloads of the requests an operation received */
+  readonly callsTo: OperationApi<typeof PIEFED_OPERATIONS>["callsTo"];
 
   /** Override an operation's response (canonical `{ error }` supported) */
-  readonly on: OperationApi<PiefedOperation>["on"];
+  readonly on: OperationApi<typeof PIEFED_OPERATIONS>["on"];
 
   /** Override an operation's next response only, then fall back */
-  readonly once: OperationApi<PiefedOperation>["once"];
+  readonly once: OperationApi<typeof PIEFED_OPERATIONS>["once"];
 
   /** Semantic content store the default routes are derived from */
   readonly seed = new SeedStore();
 
-  /** Wait until a request for an operation is recorded */
-  readonly waitForCallTo: OperationApi<PiefedOperation>["waitForCallTo"];
+  /** Wait for an operation's next request; resolves its canonical payload */
+  readonly waitForPayload: OperationApi<
+    typeof PIEFED_OPERATIONS
+  >["waitForPayload"];
 
   constructor({
     host = "piefed.test",
@@ -104,7 +262,7 @@ export class FakePiefedInstance extends FakeInstance {
     this.build = build;
     const seed = this.seed;
 
-    const api = this.buildOperationApi(PIEFED_ROUTES, (error) => {
+    const api = this.buildOperationApi(PIEFED_OPERATIONS, (error) => {
       const status = error.status ?? 400;
       return {
         json: {
@@ -118,7 +276,7 @@ export class FakePiefedInstance extends FakeInstance {
     this.callsTo = api.callsTo;
     this.on = api.on;
     this.once = api.once;
-    this.waitForCallTo = api.waitForCallTo;
+    this.waitForPayload = api.waitForPayload;
 
     // seed → wire
     const person = (subject: SeedPerson) =>

--- a/test/testing-request-decoders.test.ts
+++ b/test/testing-request-decoders.test.ts
@@ -1,0 +1,197 @@
+// Request-decoder round trip: call the real ThreadiverseClient with a
+// canonical payload, then assert the fake decoded the wire request back to
+// that same payload. This pins the decoders to the adapters — consumer
+// tests can assert on `callsTo()`/`waitForPayload()` payloads knowing they
+// mean exactly what the app passed to threadiverse, on every provider.
+
+import { describe, expect, it } from "vitest";
+
+import { FakeLemmyV1Instance, FakePiefedInstance } from "../src/testing";
+import ThreadiverseClient from "../src/ThreadiverseClient";
+
+// Each scenario: invoke the canonical operation, then expect the decoded
+// payload to contain exactly these canonical fields. Responses are mostly
+// unmocked (requests record before the 404 rejects) — errors are swallowed.
+const SCENARIOS = [
+  {
+    expected: { is_upvote: true, post_id: 42 },
+    invoke: (c: ThreadiverseClient) =>
+      c.likePost({ is_upvote: true, post_id: 42 }),
+    operation: "likePost",
+  },
+  {
+    expected: { comment_id: 7, is_upvote: false },
+    invoke: (c: ThreadiverseClient) =>
+      c.likeComment({ comment_id: 7, is_upvote: false }),
+    operation: "likeComment",
+  },
+  {
+    expected: { post_id: 42, save: true },
+    invoke: (c: ThreadiverseClient) => c.savePost({ post_id: 42, save: true }),
+    operation: "savePost",
+  },
+  {
+    expected: { comment_id: 7, save: true },
+    invoke: (c: ThreadiverseClient) =>
+      c.saveComment({ comment_id: 7, save: true }),
+    operation: "saveComment",
+  },
+  {
+    expected: { deleted: true, post_id: 42 },
+    invoke: (c: ThreadiverseClient) =>
+      c.deletePost({ deleted: true, post_id: 42 }),
+    operation: "deletePost",
+  },
+  {
+    expected: { comment_id: 7, deleted: true },
+    invoke: (c: ThreadiverseClient) =>
+      c.deleteComment({ comment_id: 7, deleted: true }),
+    operation: "deleteComment",
+  },
+  {
+    expected: { community_id: 9, follow: true },
+    invoke: (c: ThreadiverseClient) =>
+      c.followCommunity({ community_id: 9, follow: true }),
+    operation: "followCommunity",
+  },
+  {
+    expected: { content: "hello **world**", post_id: 42 },
+    invoke: (c: ThreadiverseClient) =>
+      c.createComment({ content: "hello **world**", post_id: 42 }),
+    operation: "createComment",
+  },
+  {
+    expected: { community_id: 9, name: "A post title" },
+    invoke: (c: ThreadiverseClient) =>
+      c.createPost({ community_id: 9, name: "A post title" }),
+    operation: "createPost",
+  },
+  {
+    expected: { content: "psst", recipient_id: 5 },
+    invoke: (c: ThreadiverseClient) =>
+      c.createPrivateMessage({ content: "psst", recipient_id: 5 }),
+    operation: "createPrivateMessage",
+  },
+  {
+    expected: { post_ids: [1, 2], read: true },
+    invoke: (c: ThreadiverseClient) =>
+      c.markPostAsRead({ post_ids: [1, 2], read: true }),
+    operation: "markPostAsRead",
+  },
+  {
+    expected: { password: "hunter2", username_or_email: "alex" },
+    invoke: (c: ThreadiverseClient) =>
+      c.login({ password: "hunter2", username_or_email: "alex" }),
+    operation: "login",
+  },
+  {
+    expected: { limit: 7, type_: "local" },
+    invoke: (c: ThreadiverseClient) => c.getPosts({ limit: 7, type_: "local" }),
+    operation: "getPosts",
+  },
+  {
+    expected: { limit: 5, post_id: 42 },
+    invoke: (c: ThreadiverseClient) => c.getComments({ limit: 5, post_id: 42 }),
+    operation: "getComments",
+  },
+  {
+    expected: { search_term: "cats", type_: "communities" },
+    invoke: (c: ThreadiverseClient) =>
+      c.search({ search_term: "cats", type_: "communities" }),
+    operation: "search",
+  },
+  {
+    expected: { username: "alex" },
+    invoke: (c: ThreadiverseClient) => c.getPersonDetails({ username: "alex" }),
+    operation: "getPersonDetails",
+  },
+  {
+    expected: { id: 42 },
+    invoke: (c: ThreadiverseClient) => c.getPost({ id: 42 }),
+    operation: "getPost",
+  },
+  {
+    expected: { name: "cats" },
+    invoke: (c: ThreadiverseClient) => c.getCommunity({ name: "cats" }),
+    operation: "getCommunity",
+  },
+  {
+    expected: { q: "https://example.com/post/1" },
+    invoke: (c: ThreadiverseClient) =>
+      c.resolveObject({ q: "https://example.com/post/1" }),
+    operation: "resolveObject",
+  },
+] as const;
+
+const V1_ONLY_SCENARIOS = [
+  {
+    expected: { notification_id: 3, read: true },
+    invoke: (c: ThreadiverseClient) =>
+      c.markNotificationAsRead({
+        kind: "reply",
+        notification_id: 3,
+        read: true,
+      }),
+    operation: "markNotificationAsRead",
+  },
+  {
+    expected: { unread_only: true },
+    invoke: (c: ThreadiverseClient) =>
+      c.getNotifications({ unread_only: true }),
+    operation: "getNotifications",
+  },
+  {
+    expected: { person_id: 100 },
+    invoke: (c: ThreadiverseClient) => c.listPersonContent({ person_id: 100 }),
+    operation: "listPersonContent",
+  },
+] as const;
+
+async function swallow(promise: Promise<unknown>) {
+  try {
+    await promise;
+  } catch {
+    // Unmocked responses reject — the request was still recorded first
+  }
+}
+
+describe.each([
+  ["lemmyv1", () => new FakeLemmyV1Instance()],
+  ["piefed", () => new FakePiefedInstance()],
+] as const)("%s request decoders", (mode, makeFake) => {
+  it.each(SCENARIOS)(
+    "$operation round-trips its canonical payload",
+    async ({ expected, invoke, operation }) => {
+      const fake = makeFake();
+      const client = new ThreadiverseClient(fake.origin, fake.clientOptions());
+
+      await swallow(invoke(client));
+
+      const payloads = fake.callsTo(operation);
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0]).toMatchObject(expected);
+    },
+  );
+
+  it("mode sanity", async () => {
+    const fake = makeFake();
+    const client = new ThreadiverseClient(fake.origin, fake.clientOptions());
+    expect((await client.connect()).mode).toBe(mode);
+  });
+});
+
+describe("lemmyv1-only request decoders", () => {
+  it.each(V1_ONLY_SCENARIOS)(
+    "$operation round-trips its canonical payload",
+    async ({ expected, invoke, operation }) => {
+      const fake = new FakeLemmyV1Instance();
+      const client = new ThreadiverseClient(fake.origin, fake.clientOptions());
+
+      await swallow(invoke(client));
+
+      const payloads = fake.callsTo(operation);
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0]).toMatchObject(expected);
+    },
+  );
+});

--- a/test/testing-request-decoders.test.ts
+++ b/test/testing-request-decoders.test.ts
@@ -20,6 +20,18 @@ const SCENARIOS = [
     operation: "likePost",
   },
   {
+    // Unvote: is_upvote omitted must survive the round trip
+    expected: { post_id: 42 },
+    invoke: (c: ThreadiverseClient) => c.likePost({ post_id: 42 }),
+    operation: "likePost",
+  },
+  {
+    expected: { limit: 7, type_: "moderator_view" },
+    invoke: (c: ThreadiverseClient) =>
+      c.getPosts({ limit: 7, type_: "moderator_view" }),
+    operation: "getPosts",
+  },
+  {
     expected: { comment_id: 7, is_upvote: false },
     invoke: (c: ThreadiverseClient) =>
       c.likeComment({ comment_id: 7, is_upvote: false }),
@@ -169,7 +181,7 @@ describe.each([
 
       const payloads = fake.callsTo(operation);
       expect(payloads).toHaveLength(1);
-      expect(payloads[0]).toMatchObject(expected);
+      expect(payloads[0]).toEqual(expected);
     },
   );
 
@@ -191,7 +203,7 @@ describe("lemmyv1-only request decoders", () => {
 
       const payloads = fake.callsTo(operation);
       expect(payloads).toHaveLength(1);
-      expect(payloads[0]).toMatchObject(expected);
+      expect(payloads[0]).toEqual(expected);
     },
   );
 });

--- a/test/testing-seed-matrix.test.ts
+++ b/test/testing-seed-matrix.test.ts
@@ -91,14 +91,14 @@ describe.each([
     expect(data).toHaveLength(1);
   });
 
-  it("records calls by operation name", async () => {
+  it("records canonical payloads by operation name", async () => {
     const { client, fake } = setup();
 
     await client.getPosts({ limit: 7 });
 
-    const calls = fake.callsTo("getPosts");
-    expect(calls).toHaveLength(1);
-    expect(calls[0]!.query.get("limit")).toBe("7");
+    const payloads = fake.callsTo("getPosts");
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({ limit: 7 });
   });
 
   it("rejects account endpoints when nobody is logged in", async () => {


### PR DESCRIPTION
Per design discussion: consumer e2e tests should never inspect raw wire requests (`query.get("type_")`, body shapes) — that's threadiverse's transformation contract, tested here. The fakes now decode wire requests back to **canonical threadiverse payloads**:

- `callsTo("likePost")` → `[{ post_id: 42, is_upvote: true }]`, typed from `BaseClient` params — identical assertion text on every provider (piefed's `score` and `title`/`body` renames are decoded away)
- `waitForPayload(op, predicate?)` replaces `waitForCallTo` (v0: removed, not deprecated) — sync + canonical assertion in one step
- ops without decoders throw, pointing at `calls()` (wire escape hatch)
- **round-trip contract test**: 43 scenarios × both providers — real client called with a canonical payload, decoded payload must match. Already earned its keep: caught the v1 search decoder assuming `q` (wire is `search_term`) and PieFed's duplicated `title` leaking into payloads.

This unblocks fully provider-agnostic request assertions in Voyager (the last wire dependency in its specs), i.e. true provider-matrix e2e.