### PR TITLE
feat: user-facing error message helpers

### DIFF
--- a/src/errorMessages.ts
+++ b/src/errorMessages.ts
@@ -1,0 +1,91 @@
+import {
+  AccountDeletedError,
+  BannedError,
+  CantBlockAdminError,
+  EmailNotVerifiedError,
+  Incorrect2faError,
+  IncorrectLoginError,
+  InvalidBotActionError,
+  NotFoundError,
+  RateLimitedError,
+  RegistrationApplicationPendingError,
+} from "./errors";
+
+/** User-facing message for a failed `blockPerson()` */
+export function getBlockUserErrorMessage(
+  error: unknown,
+  personName: string,
+): string {
+  return getErrorMessage(
+    error,
+    (error) => {
+      if (error instanceof CantBlockAdminError)
+        return `${personName} is an admin. You can't block admins.`;
+    },
+    "Problem blocking user. Please try again.",
+  );
+}
+
+/**
+ * Default English user-facing message for an error, with per-action
+ * specifics supplied by `customErrorMap`. Rate limiting is handled here —
+ * it applies to any endpoint, not just custom-mapped ones.
+ *
+ * Building blocks for the action-specific helpers below; use directly to
+ * write your own.
+ */
+export function getErrorMessage(
+  error: unknown,
+  customErrorMap?: (error: Error) => string | undefined,
+  unknownErrorMessage?: string,
+): string {
+  if (!(error instanceof Error))
+    return "Unknown error occurred, please try again.";
+
+  if (error instanceof RateLimitedError) {
+    return "Too many requests. Please wait a moment and try again.";
+  }
+
+  const message = customErrorMap?.(error);
+
+  if (message) return message;
+
+  return unknownErrorMessage ?? "Connection error, please try again.";
+}
+
+/** User-facing message for a failed `login()`/`register()` attempt */
+export function getLoginErrorMessage(
+  error: unknown,
+  instanceActorId: string,
+): string {
+  return getErrorMessage(error, (error) => {
+    switch (true) {
+      case error instanceof Incorrect2faError:
+        return "Incorrect 2nd factor code. Please try again.";
+      case error instanceof NotFoundError:
+        return `User not found. Is your account on ${instanceActorId}?`;
+      case error instanceof IncorrectLoginError:
+        return `Incorrect login credentials for ${instanceActorId}. Please try again.`;
+      case error instanceof EmailNotVerifiedError:
+        return `Email not verified. Please check your inbox. Request a new verification email from https://${instanceActorId}.`;
+      case error instanceof BannedError:
+        return "You have been banned.";
+      case error instanceof AccountDeletedError:
+        return "Account deleted.";
+      case error instanceof RegistrationApplicationPendingError:
+        return "Signup approval pending, try again later.";
+    }
+  });
+}
+
+/** User-facing message for a failed `likePost()`/`likeComment()` */
+export function getVoteErrorMessage(error: unknown): string {
+  return getErrorMessage(
+    error,
+    (error) => {
+      if (error instanceof InvalidBotActionError)
+        return "You marked your account as a bot, so you can't vote.";
+    },
+    "Problem voting, please try again.",
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./BaseClient";
+export * from "./errorMessages";
 export * from "./errors";
 export * from "./providers";
 export {

--- a/test/errorMessages.test.ts
+++ b/test/errorMessages.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getBlockUserErrorMessage,
+  getErrorMessage,
+  getLoginErrorMessage,
+  getVoteErrorMessage,
+} from "../src/errorMessages";
+import { createResponseError } from "../src/errors";
+
+describe("getLoginErrorMessage", () => {
+  it("maps login conditions from any provider", () => {
+    expect(
+      getLoginErrorMessage(
+        createResponseError("incorrect_login", { software: "lemmy" }),
+        "lemmy.world",
+      ),
+    ).toBe("Incorrect login credentials for lemmy.world. Please try again.");
+
+    // PieFed's wire code maps to the same condition, same message
+    expect(
+      getLoginErrorMessage(
+        createResponseError("incorrect_login", { software: "piefed" }),
+        "piefed.social",
+      ),
+    ).toContain("piefed.social");
+  });
+
+  it("rate limiting outranks the custom map", () => {
+    expect(
+      getLoginErrorMessage(createResponseError("too_many_requests"), "x"),
+    ).toBe("Too many requests. Please wait a moment and try again.");
+  });
+
+  it("falls back for unmapped codes and non-errors", () => {
+    expect(
+      getLoginErrorMessage(createResponseError("some_new_code"), "x"),
+    ).toBe("Connection error, please try again.");
+    expect(getLoginErrorMessage(undefined, "x")).toBe(
+      "Unknown error occurred, please try again.",
+    );
+  });
+});
+
+describe("getVoteErrorMessage", () => {
+  it("maps bot-action and uses the vote fallback", () => {
+    expect(getVoteErrorMessage(createResponseError("invalid_bot_action"))).toBe(
+      "You marked your account as a bot, so you can't vote.",
+    );
+    expect(getVoteErrorMessage(new Error("whatever"))).toBe(
+      "Problem voting, please try again.",
+    );
+  });
+});
+
+describe("getBlockUserErrorMessage", () => {
+  it("interpolates the person name for admin blocks", () => {
+    expect(
+      getBlockUserErrorMessage(createResponseError("cant_block_admin"), "sam"),
+    ).toBe("sam is an admin. You can't block admins.");
+  });
+});
+
+describe("getErrorMessage", () => {
+  it("supports custom maps over condition classes", () => {
+    expect(
+      getErrorMessage(createResponseError("not_found"), () => "custom"),
+    ).toBe("custom");
+  });
+});


### PR DESCRIPTION
Moves Voyager's error→message helpers into the library, rebuilt on the condition classes: `getErrorMessage` (generic: rate-limit fast path applies to any endpoint, then a custom map, then fallbacks) plus `getLoginErrorMessage`/`getVoteErrorMessage`/`getBlockUserErrorMessage`. Because the condition classes normalize across providers, PieFed errors get the same copy for free. Lets Voyager delete `helpers/lemmyErrors.ts` outright (its remaining long-tail call sites use `isErrorCode` directly).