### PR TITLE
test: seed/decoder gaps from the Voyager spec conversion

### DIFF
--- a/src/testing/lemmyv1/index.ts
+++ b/src/testing/lemmyv1/index.ts
@@ -76,8 +76,11 @@ const LEMMY_V1_OPERATIONS = {
       return {
         limit: numberish(q.limit),
         max_depth: numberish(q.max_depth),
+        page_cursor: q.page_cursor,
+        parent_id: numberish(q.parent_id),
         post_id: numberish(q.post_id),
-      };
+        sort: q.sort,
+      } as Payload<"getComments">;
     },
     route: "GET /api/v4/comment/list",
   },
@@ -117,9 +120,11 @@ const LEMMY_V1_OPERATIONS = {
       return {
         community_name: q.community_name,
         limit: numberish(q.limit),
+        page_cursor: q.page_cursor,
+        sort: q.sort,
         // v1 wire listing types are already canonical lowercase
-        type_: q.type_ as Payload<"getPosts">["type_"],
-      };
+        type_: q.type_,
+      } as Payload<"getPosts">;
     },
     route: "GET /api/v4/post/list",
   },
@@ -144,6 +149,9 @@ const LEMMY_V1_OPERATIONS = {
     route: "GET /api/v4/person/content",
   },
   login: { decode: body<"login">(), route: "POST /api/v4/account/auth/login" },
+  markAllAsRead: {
+    route: "POST /api/v4/account/notification/mark_as_read/all",
+  },
   markNotificationAsRead: {
     // v1 drops `kind` on the wire — payload is partial
     decode: body<"markNotificationAsRead">(),
@@ -169,10 +177,12 @@ const LEMMY_V1_OPERATIONS = {
       const q = query(call);
       return {
         limit: numberish(q.limit),
+        page_cursor: q.page_cursor,
         search_term: q.search_term,
+        sort: q.sort,
         // v1 wire search types are already canonical lowercase
-        type_: q.type_ as Payload<"search">["type_"],
-      };
+        type_: q.type_,
+      } as Payload<"search">;
     },
     route: "GET /api/v4/search",
   },
@@ -320,9 +330,15 @@ export class FakeLemmyV1Instance extends FakeInstance {
 
     this.mock("GET /api/v4/comment/list", (call) => {
       const postId = call.query.get("post_id");
-      const comments = postId
+      const parentId = call.query.get("parent_id");
+      let comments = postId
         ? seed.comments.filter((comment) => comment.post.id === Number(postId))
         : seed.comments;
+      // parent_id = the comment's subtree (path segments include it)
+      if (parentId)
+        comments = comments.filter((comment) =>
+          comment.path.split(".").includes(parentId),
+        );
       return { json: build.pagedResponse(comments.map(commentView)) };
     });
 
@@ -406,6 +422,27 @@ export class FakeLemmyV1Instance extends FakeInstance {
     // Fire-and-forget side effect of many logged-in interactions
     this.mock("POST /api/v4/post/mark_as_read/many", {
       json: { success: true },
+    });
+
+    // Write routes mutate the seed store, so derived unread counts and
+    // notification lists reflect the change on subsequent reads
+    this.mock("POST /api/v4/account/notification/mark_as_read", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { notification_id, read } = call.body as {
+        notification_id: number;
+        read: boolean;
+      };
+      const notification = seed.notifications.find(
+        (candidate) => candidate.id === notification_id,
+      );
+      if (notification) notification.read = read;
+      return { json: { success: true } };
+    });
+
+    this.mock("POST /api/v4/account/notification/mark_as_read/all", () => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      for (const notification of seed.notifications) notification.read = true;
+      return { json: { success: true } };
     });
   }
 }

--- a/src/testing/piefed/index.ts
+++ b/src/testing/piefed/index.ts
@@ -115,8 +115,12 @@ const PIEFED_OPERATIONS = {
       return {
         limit: numberish(q.limit),
         max_depth: numberish(q.max_depth),
+        // piefed pages with numbers; canonical page_cursor is the string
+        page_cursor: q.page,
+        parent_id: numberish(q.parent_id),
         post_id: numberish(q.post_id),
-      };
+        sort: q.sort,
+      } as Payload<"getComments">;
     },
     route: "GET /api/alpha/comment/list",
   },
@@ -144,9 +148,12 @@ const PIEFED_OPERATIONS = {
       return {
         community_name: q.community_name,
         limit: numberish(q.limit),
+        // piefed pages with numbers; canonical page_cursor is the string
+        page_cursor: q.page,
+        sort: q.sort,
         type_:
           q.type_ === undefined ? undefined : LISTING_TYPE_FROM_WIRE[q.type_],
-      };
+      } as Payload<"getPosts">;
     },
     route: "GET /api/alpha/post/list",
   },
@@ -193,9 +200,11 @@ const PIEFED_OPERATIONS = {
       const q = query(call);
       return {
         limit: numberish(q.limit),
+        page_cursor: q.page,
         search_term: q.q,
-        type_: q.type_?.toLowerCase() as Payload<"search">["type_"],
-      };
+        sort: q.sort,
+        type_: q.type_?.toLowerCase(),
+      } as Payload<"search">;
     },
     route: "GET /api/alpha/search",
   },
@@ -368,6 +377,7 @@ export class FakePiefedInstance extends FakeInstance {
       const postId = call.query.get("post_id");
       // The piefed adapter implements listPersonContent via person_id here
       const personId = call.query.get("person_id");
+      const parentId = call.query.get("parent_id");
       let comments = seed.comments;
       if (postId)
         comments = comments.filter(
@@ -376,6 +386,11 @@ export class FakePiefedInstance extends FakeInstance {
       if (personId)
         comments = comments.filter(
           (comment) => comment.creator.id === Number(personId),
+        );
+      // parent_id = the comment's subtree (path segments include it)
+      if (parentId)
+        comments = comments.filter((comment) =>
+          comment.path.split(".").includes(parentId),
         );
       return { json: build.commentListResponse(comments.map(commentView)) };
     });

--- a/src/testing/seed.ts
+++ b/src/testing/seed.ts
@@ -81,6 +81,16 @@ export class SeedStore {
   // High start so explicit ids in tests never collide with generated ones
   #nextId = 1000;
 
+  /** Wipe all seeded content (e.g. to replace a fixture's default feed) */
+  clear(): void {
+    this.comments = [];
+    this.communities = [];
+    this.loggedInPerson = undefined;
+    this.notifications = [];
+    this.people = [];
+    this.posts = [];
+  }
+
   comment(over: {
     childCount?: number;
     content: string;
@@ -115,7 +125,9 @@ export class SeedStore {
     over: { id?: number; name?: string; title?: string } = {},
   ): SeedCommunity {
     const community: SeedCommunity = {
-      id: over.id ?? this.#nextId++,
+      // First community defaults to 111 so seeds agree with the wire-level
+      // builders' default community out of the box
+      id: over.id ?? (this.communities.length === 0 ? 111 : this.#nextId++),
       name: over.name ?? "test_comm",
       title: over.title ?? "Test Community",
     };
@@ -181,6 +193,8 @@ export class SeedStore {
     content: string;
     creator: SeedPerson;
     id?: number;
+    /** Pin the inbox notification's id (for mark-as-read assertions) */
+    notificationId?: number;
     read?: boolean;
     recipient?: SeedPerson;
   }): SeedPrivateMessage {
@@ -199,7 +213,7 @@ export class SeedStore {
     };
 
     this.notifications.push({
-      id: this.#nextId++,
+      id: over.notificationId ?? this.#nextId++,
       kind: "private_message",
       message,
       read: over.read ?? false,

--- a/test/testing-request-decoders.test.ts
+++ b/test/testing-request-decoders.test.ts
@@ -102,8 +102,9 @@ const SCENARIOS = [
     operation: "getPosts",
   },
   {
-    expected: { limit: 5, post_id: 42 },
-    invoke: (c: ThreadiverseClient) => c.getComments({ limit: 5, post_id: 42 }),
+    expected: { limit: 5, parent_id: 7, post_id: 42 },
+    invoke: (c: ThreadiverseClient) =>
+      c.getComments({ limit: 5, parent_id: 7, post_id: 42 }),
     operation: "getComments",
   },
   {
@@ -136,6 +137,12 @@ const SCENARIOS = [
 ] as const;
 
 const V1_ONLY_SCENARIOS = [
+  {
+    expected: { page_cursor: "abc123", sort: "hot" },
+    invoke: (c: ThreadiverseClient) =>
+      c.getPosts({ mode: "lemmyv1", page_cursor: "abc123", sort: "hot" }),
+    operation: "getPosts",
+  },
   {
     expected: { notification_id: 3, read: true },
     invoke: (c: ThreadiverseClient) =>

--- a/test/testing-seed-matrix.test.ts
+++ b/test/testing-seed-matrix.test.ts
@@ -109,6 +109,39 @@ describe.each([
     );
   });
 
+  it("filters comment subtrees by parent_id", async () => {
+    const { client, fake, post } = setup();
+
+    // A small tree on the seeded post: parent with one child, plus an
+    // unrelated top-level comment
+    const parent = fake.seed.comment({ content: "parent", id: 20, post });
+    fake.seed.comment({
+      content: "child",
+      id: 21,
+      path: `0.${parent.id}.21`,
+      post,
+    });
+    fake.seed.comment({ content: "unrelated", id: 22, post });
+
+    const { data } = await client.getComments({
+      parent_id: parent.id,
+      post_id: post.id,
+    });
+    expect(data.map((view) => view.comment.content).sort()).toEqual([
+      "child",
+      "parent",
+    ]);
+  });
+
+  it("seed.clear() empties the derived feed", async () => {
+    const { client, fake } = setup();
+
+    fake.seed.clear();
+
+    const { data } = await client.getPosts({});
+    expect(data).toHaveLength(0);
+  });
+
   it("listPersonContent only returns the person's content", async () => {
     const { alex, client, fake, post } = setup();
 
@@ -166,5 +199,42 @@ describe("seeded notifications (lemmyv1)", () => {
       unread_only: true,
     });
     expect(unreadOnly.map((view) => view.notification.kind)).toEqual(["reply"]);
+  });
+
+  it("mark-as-read writes mutate derived seed state", async () => {
+    const fake = new FakeLemmyV1Instance();
+    const seed = fake.seed;
+
+    const alex = seed.person({ name: "alex" });
+    const other = seed.person({ name: "other" });
+    seed.loggedInAs(alex);
+
+    const reply = seed.reply({
+      comment: seed.comment({ content: "hi", creator: other }),
+      id: 301,
+    });
+    seed.privateMessage({
+      content: "psst",
+      creator: other,
+      notificationId: 302,
+    });
+
+    const client = new ThreadiverseClient(fake.origin, fake.clientOptions());
+
+    expect((await client.getUnreadCount()).replies).toBe(2);
+
+    await client.markNotificationAsRead({
+      kind: "reply",
+      notification_id: reply.id,
+      read: true,
+    });
+    expect((await client.getUnreadCount()).replies).toBe(1);
+    expect(fake.callsTo("markNotificationAsRead")[0]).toEqual({
+      notification_id: 301,
+      read: true,
+    });
+
+    await client.markAllAsRead();
+    expect((await client.getUnreadCount()).replies).toBe(0);
   });
 });


### PR DESCRIPTION
Closes the TODO(seed) gap list the Voyager spec conversion produced: sort/page_cursor/parent_id decoding (round-trip tested), parent_id subtree filtering in derived comment lists (both providers), mark-as-read writes mutating seed state so derived unread counts respond (v1), seed.clear() for replacing fixture defaults, first-community id aligned with wire builders (111), and pinnable private-message notification ids. Remaining known gap: PieFed notification derivation — next PR.