### PR TITLE
test: derive PieFed notifications from the seed store

### DIFF
--- a/src/testing/piefed/builders.ts
+++ b/src/testing/piefed/builders.ts
@@ -262,6 +262,81 @@ export function createPiefedBuilders({
     };
   }
 
+  /**
+   * `GET /api/alpha/user/replies` / `/user/mentions` item. PieFed reuses
+   * CommentReplyView for both; the notification identity is
+   * `comment_reply.id`.
+   */
+  function commentReplyView(over: {
+    comment: Wire<Schemas["CommentView"]>;
+    id: number;
+    read?: boolean;
+    recipient: Wire<Schemas["Person"]>;
+  }): Wire<Schemas["CommentReplyView"]> {
+    return {
+      activity_alert: false,
+      comment: over.comment.comment,
+      comment_reply: {
+        comment_id: over.comment.comment.id,
+        id: over.id,
+        published: over.comment.comment.published,
+        read: over.read ?? false,
+        recipient_id: over.recipient.id,
+      },
+      community: over.comment.community,
+      counts: over.comment.counts,
+      creator: over.comment.creator,
+      creator_banned_from_community: false,
+      creator_blocked: false,
+      creator_is_admin: false,
+      creator_is_moderator: false,
+      my_vote: 0,
+      post: over.comment.post,
+      recipient: over.recipient,
+      saved: false,
+      subscribed: "NotSubscribed",
+    };
+  }
+
+  function privateMessageView(over: {
+    content: string;
+    creator: Wire<Schemas["Person"]>;
+    id: number;
+    read?: boolean;
+    recipient: Wire<Schemas["Person"]>;
+  }): Wire<Schemas["PrivateMessageView"]> {
+    return {
+      creator: over.creator,
+      private_message: {
+        ap_id: `https://${host}/private_message/${over.id}`,
+        content: over.content,
+        creator_id: over.creator.id,
+        deleted: false,
+        id: over.id,
+        local: true,
+        published: now,
+        read: over.read ?? false,
+        recipient_id: over.recipient.id,
+      },
+      recipient: over.recipient,
+    };
+  }
+
+  /** `GET /api/alpha/user/replies` + `/user/mentions` response envelope */
+  function repliesResponse(
+    replies: Wire<Schemas["CommentReplyView"]>[],
+    nextPage: null | string = null,
+  ): Wire<Schemas["UserRepliesResponse"]> {
+    return { next_page: nextPage, replies };
+  }
+
+  /** `GET /api/alpha/private_message/list` response envelope */
+  function privateMessageListResponse(
+    private_messages: Wire<Schemas["PrivateMessageView"]>[],
+  ): Wire<Schemas["ListPrivateMessagesResponse"]> {
+    return { private_messages };
+  }
+
   /** `GET /api/alpha/post/list` (getPosts) response envelope */
   function postListResponse(
     posts: Wire<Schemas["PostView"]>[],
@@ -280,6 +355,7 @@ export function createPiefedBuilders({
 
   return {
     commentListResponse,
+    commentReplyView,
     commentView,
     community,
     communityResponse,
@@ -290,6 +366,9 @@ export function createPiefedBuilders({
     post,
     postListResponse,
     postView,
+    privateMessageListResponse,
+    privateMessageView,
+    repliesResponse,
     userResponse,
   };
 }

--- a/src/testing/piefed/index.ts
+++ b/src/testing/piefed/index.ts
@@ -11,6 +11,7 @@ import {
   SeedCommunity,
   SeedPerson,
   SeedPost,
+  SeedPrivateMessage,
   SeedStore,
 } from "../seed";
 import {
@@ -239,11 +240,11 @@ export interface FakePiefedInstanceOptions {
  * fake.seed.post({ name: "Hello **world**", creator: alex });
  * ```
  *
- * Derived: site, post list/detail, comment list, community, person. Use
- * `mock()` for error injection or endpoints outside this set (notably the
- * notification fan-out — `GET /api/alpha/user/replies`, `/user/mentions`,
- * `/private_message/list` — which has no typed builders yet and 404s
- * loudly when unmocked). Wire-level builders stay available on `build`.
+ * Derived: site, post list/detail, comment list, community, person,
+ * unread counts, the notification fan-out (replies/mentions/private
+ * messages), and mark-as-read writes (which mutate the seed store). Use
+ * `mock()` for error injection or endpoints outside this set. Wire-level
+ * builders stay available on `build`.
  */
 export class FakePiefedInstance extends FakeInstance {
   /** Wire-format builders bound to this instance's host */
@@ -328,6 +329,32 @@ export class FakePiefedInstance extends FakeInstance {
     // Seed misses render PieFed's real error responses as observed live
     // (piefed.social 2026-07-02): 400s whose message is prose, mapped to
     // NotFoundError in the condition table. Verified by the fidelity suite.
+    // seed → wire, notifications. PieFed reuses CommentReplyView for both
+    // replies and mentions; canonical notification identity is
+    // comment_reply.id (mapped from the seed notification id).
+    const commentReplyView = (subject: {
+      comment: SeedComment;
+      id: number;
+      read: boolean;
+    }) =>
+      build.commentReplyView({
+        comment: commentView(subject.comment),
+        id: subject.id,
+        read: subject.read,
+        recipient: person(seed.loggedInPerson ?? { id: 0, name: "nobody" }),
+      });
+    const privateMessageView = (subject: {
+      message: SeedPrivateMessage;
+      read: boolean;
+    }) =>
+      build.privateMessageView({
+        content: subject.message.content,
+        creator: person(subject.message.creator),
+        id: subject.message.id,
+        read: subject.read,
+        recipient: person(subject.message.recipient),
+      });
+
     const notFound = {
       json: {
         code: 400,
@@ -424,6 +451,78 @@ export class FakePiefedInstance extends FakeInstance {
           ).length,
         },
       };
+    });
+
+    const unreadOnly = (call: RecordedCall) =>
+      call.query.get("unread_only") === "true";
+
+    const repliesOf = (kind: "mention" | "reply", onlyUnread: boolean) =>
+      seed.notifications.flatMap((notification) =>
+        notification.kind === kind && (!onlyUnread || !notification.read)
+          ? [commentReplyView(notification)]
+          : [],
+      );
+
+    this.mock("GET /api/alpha/user/replies", (call) =>
+      seed.loggedInPerson
+        ? { json: build.repliesResponse(repliesOf("reply", unreadOnly(call))) }
+        : unauthenticated,
+    );
+
+    this.mock("GET /api/alpha/user/mentions", (call) =>
+      seed.loggedInPerson
+        ? {
+            json: build.repliesResponse(repliesOf("mention", unreadOnly(call))),
+          }
+        : unauthenticated,
+    );
+
+    this.mock("GET /api/alpha/private_message/list", (call) =>
+      seed.loggedInPerson
+        ? {
+            json: build.privateMessageListResponse(
+              seed.notifications.flatMap((notification) =>
+                notification.kind === "private_message" &&
+                (!unreadOnly(call) || !notification.read)
+                  ? [privateMessageView(notification)]
+                  : [],
+              ),
+            ),
+          }
+        : unauthenticated,
+    );
+
+    // Mark-as-read writes mutate the seed store, so derived unread counts
+    // and lists reflect them. The piefed adapter maps canonical
+    // notification_id onto comment_reply_id / private_message_id.
+    this.mock("POST /api/alpha/comment/mark_as_read", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { comment_reply_id, read } = call.body as {
+        comment_reply_id: number;
+        read: boolean;
+      };
+      const notification = seed.notifications.find(
+        (candidate) =>
+          candidate.kind !== "private_message" &&
+          candidate.id === comment_reply_id,
+      );
+      if (notification) notification.read = read;
+      return { json: { success: true } };
+    });
+
+    this.mock("POST /api/alpha/private_message/mark_as_read", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { private_message_id, read } = call.body as {
+        private_message_id: number;
+        read: boolean;
+      };
+      const notification = seed.notifications.find(
+        (candidate) =>
+          candidate.kind === "private_message" &&
+          candidate.message.id === private_message_id,
+      );
+      if (notification) notification.read = read;
+      return { json: { success: true } };
     });
 
     this.mock("GET /api/alpha/user", (call) => {

--- a/test/testing-seed-matrix.test.ts
+++ b/test/testing-seed-matrix.test.ts
@@ -142,6 +142,54 @@ describe.each([
     expect(data).toHaveLength(0);
   });
 
+  it("derives the inbox from seeded notifications", async () => {
+    const { client, fake, post } = setup();
+    const seed = fake.seed;
+
+    const me = seed.person({ name: "me" });
+    const other = seed.person({ name: "other" });
+    seed.loggedInAs(me);
+
+    seed.reply({
+      comment: seed.comment({ content: "a reply", creator: other, post }),
+      id: 301,
+    });
+    seed.mention({
+      comment: seed.comment({ content: "a mention", creator: other, post }),
+      id: 302,
+      read: true,
+    });
+    seed.privateMessage({ content: "psst", creator: other });
+
+    const { data } = await client.getNotifications({});
+    expect(data.map((view) => view.notification.kind).sort()).toEqual([
+      "mention",
+      "private_message",
+      "reply",
+    ]);
+
+    const { data: unreadOnly } = await client.getNotifications({
+      unread_only: true,
+    });
+    expect(unreadOnly.map((view) => view.notification.kind).sort()).toEqual([
+      "private_message",
+      "reply",
+    ]);
+
+    // Marking read mutates seed state on every provider
+    await client.markNotificationAsRead({
+      kind: "reply",
+      notification_id: 301,
+      read: true,
+    });
+    const { data: afterRead } = await client.getNotifications({
+      unread_only: true,
+    });
+    expect(afterRead.map((view) => view.notification.kind)).toEqual([
+      "private_message",
+    ]);
+  });
+
   it("listPersonContent only returns the person's content", async () => {
     const { alex, client, fake, post } = setup();
 


### PR DESCRIPTION
Fills the documented PieFed gap: typed `commentReplyView`/`privateMessageView` builders + `repliesResponse`/`privateMessageListResponse` envelopes, derived `/user/replies`, `/user/mentions`, `/private_message/list` routes (auth-gated, honoring the `unread_only` the adapter forwards — caught by the matrix test), and mark-as-read writes mutating seed state via the adapter's `comment_reply_id`/`private_message_id` mapping. The seeded-inbox test is now part of the provider matrix: identical seeds and assertions on lemmyv1 and piefed. Unblocks running Voyager's inbox specs cross-provider.