### PR TITLE
feat: PieFed fake derives my_user in getSite + mark-all route

### DIFF
--- a/src/testing/piefed/builders.ts
+++ b/src/testing/piefed/builders.ts
@@ -248,12 +248,59 @@ export function createPiefedBuilders({
     };
   }
 
+  function localUser(): Wire<Schemas["LocalUser"]> {
+    return {
+      accept_private_messages: "All",
+      ai_visibility: "Show",
+      bot_visibility: "Show",
+      default_comment_sort_type: "Hot",
+      default_listing_type: "All",
+      email_unread: false,
+      federate_votes: true,
+      feed_auto_follow: false,
+      feed_auto_leave: false,
+      hide_low_quality: false,
+      indexable: true,
+      newsletter: false,
+      nsfl_visibility: "Hide",
+      nsfw_visibility: "Blur",
+      reply_collapse_threshold: 0,
+      reply_hide_threshold: 0,
+      searchable: true,
+      show_bot_accounts: true,
+      show_nsfl: false,
+      show_nsfw: false,
+      show_read_posts: true,
+      show_scores: true,
+    };
+  }
+
+  /** The authenticated user's info, embedded in `GET /api/alpha/site` */
+  function myUserInfo(
+    subject: Wire<Schemas["Person"]>,
+  ): Wire<Schemas["MyUserInfo"]> {
+    return {
+      community_blocks: [],
+      discussion_languages: [],
+      follows: [],
+      instance_blocks: [],
+      local_user_view: {
+        counts: { comment_count: 0, person_id: subject.id, post_count: 0 },
+        local_user: localUser(),
+        person: subject,
+      },
+      moderates: [],
+      person_blocks: [],
+    };
+  }
+
   /** `GET /api/alpha/site` (getSite) */
   function getSiteResponse(
-    over: { name?: string } = {},
+    over: { myUser?: Wire<Schemas["Person"]>; name?: string } = {},
   ): Wire<Schemas["GetSiteResponse"]> {
     return {
       admins: [],
+      my_user: over.myUser ? myUserInfo(over.myUser) : undefined,
       site: {
         actor_id: `https://${host}/`,
         name: over.name ?? "Test piefed site",
@@ -361,6 +408,8 @@ export function createPiefedBuilders({
     communityResponse,
     communityView,
     getSiteResponse,
+    localUser,
+    myUserInfo,
     person,
     personView,
     post,

--- a/src/testing/piefed/index.ts
+++ b/src/testing/piefed/index.ts
@@ -181,6 +181,9 @@ const PIEFED_OPERATIONS = {
     },
     route: "POST /api/alpha/user/login",
   },
+  markAllAsRead: {
+    route: "POST /api/alpha/user/mark_all_as_read",
+  },
   markPostAsRead: {
     decode: body<"markPostAsRead">(),
     route: "POST /api/alpha/post/mark_as_read",
@@ -381,7 +384,10 @@ export class FakePiefedInstance extends FakeInstance {
     } as const;
 
     this.mock("GET /api/alpha/site", () => ({
-      json: build.getSiteResponse({ name: seed.siteName }),
+      json: build.getSiteResponse({
+        myUser: seed.loggedInPerson ? person(seed.loggedInPerson) : undefined,
+        name: seed.siteName,
+      }),
     }));
 
     this.mock("GET /api/alpha/post/list", (call) => {
@@ -522,6 +528,12 @@ export class FakePiefedInstance extends FakeInstance {
           candidate.message.id === private_message_id,
       );
       if (notification) notification.read = read;
+      return { json: { success: true } };
+    });
+
+    this.mock("POST /api/alpha/user/mark_all_as_read", () => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      for (const notification of seed.notifications) notification.read = true;
       return { json: { success: true } };
     });
 

--- a/test/testing-seed-matrix.test.ts
+++ b/test/testing-seed-matrix.test.ts
@@ -188,6 +188,30 @@ describe.each([
     expect(afterRead.map((view) => view.notification.kind)).toEqual([
       "private_message",
     ]);
+
+    // markAllAsRead clears the rest on every provider
+    await client.markAllAsRead();
+    const { data: afterAll } = await client.getNotifications({
+      unread_only: true,
+    });
+    expect(afterAll).toHaveLength(0);
+  });
+
+  it("includes the logged-in user in getSite", async () => {
+    const { fake } = setup();
+
+    const me = fake.seed.person({ name: "me" });
+    fake.seed.loggedInAs(me);
+
+    // A logged-in client carries auth; lemmyv1 only fetches my_user when
+    // authed, piefed always reads it from the site response
+    const client = new ThreadiverseClient(fake.origin, {
+      ...fake.clientOptions(),
+      headers: { Authorization: "Bearer test" },
+    });
+
+    const site = await client.getSite();
+    expect(site.my_user?.local_user_view.person.name).toBe("me");
   });
 
   it("listPersonContent only returns the person's content", async () => {


### PR DESCRIPTION
Wave 1 of the provider-matrix follow-ups (~/threadiverse-plan.md).

- **PieFed `getSite` includes `my_user`** when `seed.loggedInAs` — added typed `myUserInfo`/`localUser` builders (drift-checked against the OpenAPI schema), so logged-in boot works without a wire override. Retires the documented workaround in Voyager's `e2e/matrix/fixtures.ts`.
- **PieFed `mark_all_as_read`** derived route, mutating seed read-state like the v1 fake — unblocks inbox mark-all in the matrix.
- Cross-provider matrix tests: `getSite.my_user` (with client auth, since lemmyv1 gates it on auth while piefed reads it from the site response) and `markAllAsRead`.

Deferred from Wave 1: `max_depth` in derived comment lists. Making the "N more replies" test seed-based would couple the fake to Voyager's client-side `defaultCommentDepth` math and make it brittle — the honest wire-mock + canonical-payload assertion already there is the better tradeoff.

433 tests, typecheck, lint, build clean.