### PR TITLE
feat: fakes model vote/save state

### DIFF
--- a/src/ThreadiverseClient.ts
+++ b/src/ThreadiverseClient.ts
@@ -45,7 +45,6 @@ export interface ThreadiverseClientOptions extends BaseClientOptions {
  * (`./endpoints.ts`) in the class's static block; this merged interface
  * declares their types. */
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface ThreadiverseClient extends BaseClient {}
 
 class ThreadiverseClient {

--- a/src/testing/lemmyv1/builders.ts
+++ b/src/testing/lemmyv1/builders.ts
@@ -84,12 +84,32 @@ export function createLemmyV1Builders({
     };
   }
 
+  // Vote counts derived from a base score (all base votes are upvotes) plus
+  // the logged-in user's vote layered on top.
+  function votes(baseScore: number, myVote: -1 | 0 | 1) {
+    const upvotes = baseScore + (myVote === 1 ? 1 : 0);
+    const downvotes = myVote === -1 ? 1 : 0;
+    return { downvotes, score: upvotes - downvotes, upvotes };
+  }
+
+  // v1 conveys the logged-in user's vote/save via *_actions; absent (`{}`)
+  // when there's no interaction.
+  function actions(myVote: -1 | 0 | 1, saved: boolean) {
+    return {
+      saved_at: saved ? now : undefined,
+      vote_is_upvote: myVote === 0 ? undefined : myVote === 1,
+      voted_at: myVote === 0 ? undefined : now,
+    };
+  }
+
   function post(over: {
     body?: string;
     community?: Wire<LemmyV1.Community>;
     creator: Wire<LemmyV1.Person>;
     id: number;
+    myVote?: -1 | 0 | 1;
     name: string;
+    score?: number;
     url?: string;
   }): Wire<LemmyV1.Post> {
     return {
@@ -99,7 +119,6 @@ export function createLemmyV1Builders({
       community_id: over.community?.id ?? DEFAULT_COMMUNITY_ID,
       creator_id: over.creator.id,
       deleted: false,
-      downvotes: 0,
       featured_community: false,
       featured_local: false,
       federation_pending: false,
@@ -113,10 +132,9 @@ export function createLemmyV1Builders({
       published_at: now,
       removed: false,
       report_count: 0,
-      score: 1,
       unresolved_report_count: 0,
-      upvotes: 1,
       url: over.url,
+      ...votes(over.score ?? 1, over.myVote ?? 0),
     };
   }
 
@@ -125,7 +143,10 @@ export function createLemmyV1Builders({
     community?: Wire<LemmyV1.Community>;
     creator: Wire<LemmyV1.Person>;
     id: number;
+    myVote?: -1 | 0 | 1;
     name: string;
+    saved?: boolean;
+    score?: number;
     url?: string;
   }): Wire<LemmyV1.PostView> {
     const resolvedCommunity = over.community ?? community();
@@ -139,6 +160,7 @@ export function createLemmyV1Builders({
       creator_is_admin: false,
       creator_is_moderator: false,
       post: post({ ...over, community: resolvedCommunity }),
+      post_actions: actions(over.myVote ?? 0, over.saved ?? false),
       tags: [],
     };
   }
@@ -148,9 +170,12 @@ export function createLemmyV1Builders({
     content: string;
     creator?: Wire<LemmyV1.Person>;
     id: number;
+    myVote?: -1 | 0 | 1;
     path?: string;
     post: Pick<Wire<LemmyV1.PostView>, "community" | "creator" | "post">;
     published_at?: string;
+    saved?: boolean;
+    score?: number;
   }): Wire<LemmyV1.CommentView> {
     const creator = over.creator ?? over.post.creator;
 
@@ -163,7 +188,6 @@ export function createLemmyV1Builders({
         creator_id: creator.id,
         deleted: false,
         distinguished: false,
-        downvotes: 0,
         federation_pending: false,
         id: over.id,
         language_id: 0,
@@ -174,10 +198,10 @@ export function createLemmyV1Builders({
         published_at: over.published_at ?? now,
         removed: false,
         report_count: 0,
-        score: 1,
         unresolved_report_count: 0,
-        upvotes: 1,
+        ...votes(over.score ?? 1, over.myVote ?? 0),
       },
+      comment_actions: actions(over.myVote ?? 0, over.saved ?? false),
       community: over.post.community,
       creator,
       creator_banned: false,

--- a/src/testing/lemmyv1/index.ts
+++ b/src/testing/lemmyv1/index.ts
@@ -275,7 +275,10 @@ export class FakeLemmyV1Instance extends FakeInstance {
         community: community(subject.community),
         creator: person(subject.creator),
         id: subject.id,
+        myVote: subject.myVote,
         name: subject.name,
+        saved: subject.saved,
+        score: subject.score,
         url: subject.url,
       });
     const commentView = (subject: SeedComment) =>
@@ -284,9 +287,12 @@ export class FakeLemmyV1Instance extends FakeInstance {
         content: subject.content,
         creator: person(subject.creator),
         id: subject.id,
+        myVote: subject.myVote,
         path: subject.path,
         post: postView(subject.post),
         published_at: subject.published,
+        saved: subject.saved,
+        score: subject.score,
       });
     const notificationView = (subject: SeedNotification) =>
       subject.kind === "private_message"
@@ -422,6 +428,64 @@ export class FakeLemmyV1Instance extends FakeInstance {
     // Fire-and-forget side effect of many logged-in interactions
     this.mock("POST /api/v4/post/mark_as_read/many", {
       json: { success: true },
+    });
+
+    // Vote/save writes mutate the seed store, so the returned view — and
+    // every subsequent read — reflects the new state.
+    const toVote = (isUpvote: boolean | undefined): -1 | 0 | 1 =>
+      isUpvote === true ? 1 : isUpvote === false ? -1 : 0;
+
+    const findPost = (id: number) =>
+      seed.posts.find((candidate) => candidate.id === id);
+    const findComment = (id: number) =>
+      seed.comments.find((candidate) => candidate.id === id);
+
+    this.mock("POST /api/v4/post/like", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { is_upvote, post_id } = call.body as {
+        is_upvote?: boolean;
+        post_id: number;
+      };
+      const post = findPost(post_id);
+      if (!post) return notFound;
+      post.myVote = toVote(is_upvote);
+      return { json: { post_view: postView(post) } };
+    });
+
+    this.mock("POST /api/v4/comment/like", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { comment_id, is_upvote } = call.body as {
+        comment_id: number;
+        is_upvote?: boolean;
+      };
+      const comment = findComment(comment_id);
+      if (!comment) return notFound;
+      comment.myVote = toVote(is_upvote);
+      return { json: { comment_view: commentView(comment) } };
+    });
+
+    this.mock("PUT /api/v4/post/save", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { post_id, save } = call.body as {
+        post_id: number;
+        save: boolean;
+      };
+      const post = findPost(post_id);
+      if (!post) return notFound;
+      post.saved = save;
+      return { json: { post_view: postView(post) } };
+    });
+
+    this.mock("PUT /api/v4/comment/save", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { comment_id, save } = call.body as {
+        comment_id: number;
+        save: boolean;
+      };
+      const comment = findComment(comment_id);
+      if (!comment) return notFound;
+      comment.saved = save;
+      return { json: { comment_view: commentView(comment) } };
     });
 
     // Write routes mutate the seed store, so derived unread counts and

--- a/src/testing/piefed/builders.ts
+++ b/src/testing/piefed/builders.ts
@@ -125,15 +125,27 @@ export function createPiefedBuilders({
     };
   }
 
+  // Vote counts from a base score (all base votes are upvotes) plus the
+  // logged-in user's vote layered on top.
+  function votes(baseScore: number, myVote: -1 | 0 | 1) {
+    const upvotes = baseScore + (myVote === 1 ? 1 : 0);
+    const downvotes = myVote === -1 ? 1 : 0;
+    return { downvotes, score: upvotes - downvotes, upvotes };
+  }
+
   function postView(over: {
     body?: string;
     community?: Wire<Schemas["Community"]>;
     creator: Wire<Schemas["Person"]>;
     id: number;
+    myVote?: -1 | 0 | 1;
+    saved?: boolean;
+    score?: number;
     title: string;
     url?: string;
   }): Wire<Schemas["PostView"]> {
     const resolvedCommunity = over.community ?? community();
+    const myVote = over.myVote ?? 0;
 
     return {
       banned_from_community: false,
@@ -141,21 +153,20 @@ export function createPiefedBuilders({
       counts: {
         comments: 0,
         cross_posts: 0,
-        downvotes: 0,
         newest_comment_time: now,
         post_id: over.id,
         published: now,
-        score: 1,
-        upvotes: 1,
+        ...votes(over.score ?? 1, myVote),
       },
       creator: over.creator,
       creator_banned_from_community: false,
       creator_is_admin: false,
       creator_is_moderator: false,
       hidden: false,
+      my_vote: myVote,
       post: post({ ...over, community: resolvedCommunity }),
       read: false,
-      saved: false,
+      saved: over.saved ?? false,
       subscribed: "NotSubscribed",
       unread_comments: 0,
     };
@@ -166,12 +177,16 @@ export function createPiefedBuilders({
     child_count?: number;
     creator?: Wire<Schemas["Person"]>;
     id: number;
+    myVote?: -1 | 0 | 1;
     path?: string;
     post: Pick<Wire<Schemas["PostView"]>, "community" | "creator" | "post">;
     published?: string;
+    saved?: boolean;
+    score?: number;
   }): Wire<Schemas["CommentView"]> {
     const creator = over.creator ?? over.post.creator;
     const published = over.published ?? now;
+    const myVote = over.myVote ?? 0;
 
     return {
       activity_alert: false,
@@ -194,18 +209,17 @@ export function createPiefedBuilders({
       counts: {
         child_count: over.child_count ?? 0,
         comment_id: over.id,
-        downvotes: 0,
         published,
-        score: 1,
-        upvotes: 1,
+        ...votes(over.score ?? 1, myVote),
       },
       creator,
       creator_banned_from_community: false,
       creator_blocked: false,
       creator_is_admin: false,
       creator_is_moderator: false,
+      my_vote: myVote,
       post: over.post.post,
-      saved: false,
+      saved: over.saved ?? false,
       subscribed: "NotSubscribed",
     };
   }

--- a/src/testing/piefed/index.ts
+++ b/src/testing/piefed/index.ts
@@ -315,6 +315,9 @@ export class FakePiefedInstance extends FakeInstance {
         community: community(subject.community),
         creator: person(subject.creator),
         id: subject.id,
+        myVote: subject.myVote,
+        saved: subject.saved,
+        score: subject.score,
         title: subject.name,
         url: subject.url,
       });
@@ -324,9 +327,12 @@ export class FakePiefedInstance extends FakeInstance {
         child_count: subject.childCount,
         creator: person(subject.creator),
         id: subject.id,
+        myVote: subject.myVote,
         path: subject.path,
         post: postView(subject.post),
         published: subject.published,
+        saved: subject.saved,
+        score: subject.score,
       });
 
     // Seed misses render PieFed's real error responses as observed live
@@ -497,6 +503,65 @@ export class FakePiefedInstance extends FakeInstance {
           }
         : unauthenticated,
     );
+
+    // Vote/save writes mutate the seed store, so the returned view — and
+    // every subsequent read — reflects the new state. PieFed's like body
+    // carries a signed `score` (the adapter's is_upvote → 1/-1/0).
+    const toVote = (score: number | undefined): -1 | 0 | 1 =>
+      score === 1 ? 1 : score === -1 ? -1 : 0;
+
+    const findPost = (id: number) =>
+      seed.posts.find((candidate) => candidate.id === id);
+    const findComment = (id: number) =>
+      seed.comments.find((candidate) => candidate.id === id);
+
+    this.mock("POST /api/alpha/post/like", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { post_id, score } = call.body as {
+        post_id: number;
+        score?: number;
+      };
+      const post = findPost(post_id);
+      if (!post) return notFound;
+      post.myVote = toVote(score);
+      return { json: { post_view: postView(post) } };
+    });
+
+    this.mock("POST /api/alpha/comment/like", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { comment_id, score } = call.body as {
+        comment_id: number;
+        score?: number;
+      };
+      const comment = findComment(comment_id);
+      if (!comment) return notFound;
+      comment.myVote = toVote(score);
+      return { json: { comment_view: commentView(comment) } };
+    });
+
+    this.mock("PUT /api/alpha/post/save", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { post_id, save } = call.body as {
+        post_id: number;
+        save: boolean;
+      };
+      const post = findPost(post_id);
+      if (!post) return notFound;
+      post.saved = save;
+      return { json: { post_view: postView(post) } };
+    });
+
+    this.mock("PUT /api/alpha/comment/save", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { comment_id, save } = call.body as {
+        comment_id: number;
+        save: boolean;
+      };
+      const comment = findComment(comment_id);
+      if (!comment) return notFound;
+      comment.saved = save;
+      return { json: { comment_view: commentView(comment) } };
+    });
 
     // Mark-as-read writes mutate the seed store, so derived unread counts
     // and lists reflect them. The piefed adapter maps canonical

--- a/src/testing/seed.ts
+++ b/src/testing/seed.ts
@@ -16,10 +16,16 @@ export interface SeedComment {
   content: string;
   creator: SeedPerson;
   id: number;
+  /** The logged-in user's vote (mutated by like writes) */
+  myVote: -1 | 0 | 1;
   path: string;
   post: SeedPost;
   /** ISO 8601; defaults to the fake's fixed "now" */
   published?: string;
+  /** Saved by the logged-in user (mutated by save writes) */
+  saved: boolean;
+  /** Base score at `myVote` 0; the logged-in user's vote is added on top */
+  score: number;
 }
 
 export interface SeedCommunity {
@@ -53,7 +59,13 @@ export interface SeedPost {
   community: SeedCommunity;
   creator: SeedPerson;
   id: number;
+  /** The logged-in user's vote (mutated by like writes) */
+  myVote: -1 | 0 | 1;
   name: string;
+  /** Saved by the logged-in user (mutated by save writes) */
+  saved: boolean;
+  /** Base score at `myVote` 0; the logged-in user's vote is added on top */
+  score: number;
   url?: string;
 }
 
@@ -96,9 +108,12 @@ export class SeedStore {
     content: string;
     creator?: SeedPerson;
     id?: number;
+    myVote?: -1 | 0 | 1;
     path?: string;
     post?: SeedPost;
     published?: string;
+    saved?: boolean;
+    score?: number;
   }): SeedComment {
     const post = over.post ?? this.posts[0] ?? this.post({ name: "Seed post" });
     const id = over.id ?? this.#nextId++;
@@ -108,9 +123,12 @@ export class SeedStore {
       content: over.content,
       creator: over.creator ?? post.creator,
       id,
+      myVote: over.myVote ?? 0,
       path: over.path ?? `0.${id}`,
       post,
       published: over.published,
+      saved: over.saved ?? false,
+      score: over.score ?? 1,
     };
     this.comments.push(comment);
     return comment;
@@ -170,7 +188,10 @@ export class SeedStore {
     community?: SeedCommunity;
     creator?: SeedPerson;
     id?: number;
+    myVote?: -1 | 0 | 1;
     name: string;
+    saved?: boolean;
+    score?: number;
     url?: string;
   }): SeedPost {
     const post: SeedPost = {
@@ -178,7 +199,10 @@ export class SeedStore {
       community: over.community ?? this.#defaultCommunity(),
       creator: over.creator ?? this.#defaultPerson(),
       id: over.id ?? this.#nextId++,
+      myVote: over.myVote ?? 0,
       name: over.name,
+      saved: over.saved ?? false,
+      score: over.score ?? 1,
       url: over.url,
     };
     this.posts.push(post);

--- a/test/testing-seed-matrix.test.ts
+++ b/test/testing-seed-matrix.test.ts
@@ -101,6 +101,36 @@ describe.each([
     expect(payloads[0]).toMatchObject({ limit: 7 });
   });
 
+  it("derives vote/save state from write mutations", async () => {
+    const { client, fake, post } = setup();
+    fake.seed.loggedInAs(fake.seed.person({ name: "me" }));
+
+    // Seeded post starts unvoted at base score 1
+    const before = await client.getPost({ id: post.id });
+    expect(before.post_view.my_vote ?? 0).toBe(0);
+    expect(before.post_view.post.score).toBe(1);
+
+    // Upvote → returned view and subsequent reads reflect it
+    const liked = await client.likePost({ is_upvote: true, post_id: post.id });
+    expect(liked.post_view.my_vote).toBe(1);
+    expect(liked.post_view.post.score).toBe(2);
+
+    const { data: feed } = await client.getPosts({});
+    expect(feed[0]!.my_vote).toBe(1);
+    expect(feed[0]!.post.score).toBe(2);
+
+    // Unvote returns to base
+    await client.likePost({ post_id: post.id });
+    expect((await client.getPost({ id: post.id })).post_view.post.score).toBe(
+      1,
+    );
+
+    // Save
+    const saved = await client.savePost({ post_id: post.id, save: true });
+    expect(saved.post_view.saved).toBe(true);
+    expect((await client.getPost({ id: post.id })).post_view.saved).toBe(true);
+  });
+
   it("rejects account endpoints when nobody is logged in", async () => {
     const { client } = setup();
 


### PR DESCRIPTION
Wave 2 of the provider-matrix follow-ups (~/threadiverse-plan.md).

Seed `posts`/`comments` now carry mutable `myVote` / `saved` / `score` (default unvoted, base score 1). Each fake derives these into its provider's wire shape — v1 `post_actions`/`comment_actions`, PieFed `my_vote`/`saved`/`counts` — and the `like`/`save` write routes mutate the seed state, so the returned view **and every subsequent read** reflect it. Auth-gated; unvote returns to base score.

Vote math: base score is treated as upvotes; the logged-in user's vote layers on top (base 1 → upvote → score 2 / upvotes 2; downvote → score 0).

**Unlocks:** consumers can stop hand-building vote/save wire responses (Voyager's gestures + feed-interactions specs) and assert resulting scores through the derived fake. Provider-matrix test covers upvote → `my_vote`/score, unvote → base, and save, on both lemmyv1 and piefed.

435 tests, typecheck, lint, build clean.