### PR TITLE
feat: fakes derive create/edit/delete write responses

### DIFF
--- a/src/testing/lemmyv1/builders.ts
+++ b/src/testing/lemmyv1/builders.ts
@@ -106,6 +106,7 @@ export function createLemmyV1Builders({
     body?: string;
     community?: Wire<LemmyV1.Community>;
     creator: Wire<LemmyV1.Person>;
+    deleted?: boolean;
     id: number;
     myVote?: -1 | 0 | 1;
     name: string;
@@ -118,7 +119,7 @@ export function createLemmyV1Builders({
       comments: 0,
       community_id: over.community?.id ?? DEFAULT_COMMUNITY_ID,
       creator_id: over.creator.id,
-      deleted: false,
+      deleted: over.deleted ?? false,
       featured_community: false,
       featured_local: false,
       federation_pending: false,
@@ -142,6 +143,7 @@ export function createLemmyV1Builders({
     body?: string;
     community?: Wire<LemmyV1.Community>;
     creator: Wire<LemmyV1.Person>;
+    deleted?: boolean;
     id: number;
     myVote?: -1 | 0 | 1;
     name: string;
@@ -169,6 +171,7 @@ export function createLemmyV1Builders({
     child_count?: number;
     content: string;
     creator?: Wire<LemmyV1.Person>;
+    deleted?: boolean;
     id: number;
     myVote?: -1 | 0 | 1;
     path?: string;
@@ -186,7 +189,7 @@ export function createLemmyV1Builders({
         child_count: over.child_count ?? 0,
         content: over.content,
         creator_id: creator.id,
-        deleted: false,
+        deleted: over.deleted ?? false,
         distinguished: false,
         federation_pending: false,
         id: over.id,

--- a/src/testing/lemmyv1/index.ts
+++ b/src/testing/lemmyv1/index.ts
@@ -274,6 +274,7 @@ export class FakeLemmyV1Instance extends FakeInstance {
         body: subject.body,
         community: community(subject.community),
         creator: person(subject.creator),
+        deleted: subject.deleted,
         id: subject.id,
         myVote: subject.myVote,
         name: subject.name,
@@ -286,6 +287,7 @@ export class FakeLemmyV1Instance extends FakeInstance {
         child_count: subject.childCount,
         content: subject.content,
         creator: person(subject.creator),
+        deleted: subject.deleted,
         id: subject.id,
         myVote: subject.myVote,
         path: subject.path,
@@ -485,6 +487,101 @@ export class FakeLemmyV1Instance extends FakeInstance {
       const comment = findComment(comment_id);
       if (!comment) return notFound;
       comment.saved = save;
+      return { json: { comment_view: commentView(comment) } };
+    });
+
+    // Create/edit/delete writes mutate the seed store; the returned view and
+    // subsequent reads reflect the change.
+    this.mock("POST /api/v4/post", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const wire = call.body as {
+        body?: string;
+        community_id: number;
+        name: string;
+        url?: string;
+      };
+      const community = seed.communities.find(
+        (candidate) => candidate.id === wire.community_id,
+      );
+      const post = seed.post({
+        body: wire.body,
+        community,
+        creator: seed.loggedInPerson,
+        name: wire.name,
+        url: wire.url,
+      });
+      return { json: { post_view: postView(post) } };
+    });
+
+    this.mock("PUT /api/v4/post", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const wire = call.body as {
+        body?: string;
+        name?: string;
+        post_id: number;
+        url?: string;
+      };
+      const post = findPost(wire.post_id);
+      if (!post) return notFound;
+      if (wire.name !== undefined) post.name = wire.name;
+      if (wire.body !== undefined) post.body = wire.body;
+      if (wire.url !== undefined) post.url = wire.url;
+      return { json: { post_view: postView(post) } };
+    });
+
+    this.mock("DELETE /api/v4/post", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { deleted, post_id } = call.body as {
+        deleted: boolean;
+        post_id: number;
+      };
+      const post = findPost(post_id);
+      if (!post) return notFound;
+      post.deleted = deleted;
+      return { json: { post_view: postView(post) } };
+    });
+
+    this.mock("POST /api/v4/comment", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const wire = call.body as {
+        content: string;
+        parent_id?: number;
+        post_id: number;
+      };
+      const post = findPost(wire.post_id);
+      if (!post) return notFound;
+      const parent = wire.parent_id ? findComment(wire.parent_id) : undefined;
+      const comment = seed.comment({
+        content: wire.content,
+        creator: seed.loggedInPerson,
+        post,
+      });
+      // Nest under the parent (path segments carry the ancestry)
+      if (parent) comment.path = `${parent.path}.${comment.id}`;
+      return { json: { comment_view: commentView(comment) } };
+    });
+
+    this.mock("PUT /api/v4/comment", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { comment_id, content } = call.body as {
+        comment_id: number;
+        content: string;
+      };
+      const comment = findComment(comment_id);
+      if (!comment) return notFound;
+      comment.content = content;
+      return { json: { comment_view: commentView(comment) } };
+    });
+
+    this.mock("DELETE /api/v4/comment", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { comment_id, deleted } = call.body as {
+        comment_id: number;
+        deleted: boolean;
+      };
+      const comment = findComment(comment_id);
+      if (!comment) return notFound;
+      comment.deleted = deleted;
       return { json: { comment_view: commentView(comment) } };
     });
 

--- a/src/testing/piefed/builders.ts
+++ b/src/testing/piefed/builders.ts
@@ -99,6 +99,7 @@ export function createPiefedBuilders({
     body?: string;
     community?: Wire<Schemas["Community"]>;
     creator: Wire<Schemas["Person"]>;
+    deleted?: boolean;
     id: number;
     title: string;
     url?: string;
@@ -108,7 +109,7 @@ export function createPiefedBuilders({
       ap_id: `https://${host}/post/${over.id}`,
       body: over.body,
       community_id: over.community?.id ?? DEFAULT_COMMUNITY_ID,
-      deleted: false,
+      deleted: over.deleted ?? false,
       id: over.id,
       instance_sticky: false,
       language_id: 0,
@@ -137,6 +138,7 @@ export function createPiefedBuilders({
     body?: string;
     community?: Wire<Schemas["Community"]>;
     creator: Wire<Schemas["Person"]>;
+    deleted?: boolean;
     id: number;
     myVote?: -1 | 0 | 1;
     saved?: boolean;
@@ -176,6 +178,7 @@ export function createPiefedBuilders({
     body: string;
     child_count?: number;
     creator?: Wire<Schemas["Person"]>;
+    deleted?: boolean;
     id: number;
     myVote?: -1 | 0 | 1;
     path?: string;
@@ -194,7 +197,7 @@ export function createPiefedBuilders({
       comment: {
         ap_id: `https://${host}/comment/${over.id}`,
         body: over.body,
-        deleted: false,
+        deleted: over.deleted ?? false,
         distinguished: false,
         id: over.id,
         language_id: 0,

--- a/src/testing/piefed/index.ts
+++ b/src/testing/piefed/index.ts
@@ -314,6 +314,7 @@ export class FakePiefedInstance extends FakeInstance {
         body: subject.body,
         community: community(subject.community),
         creator: person(subject.creator),
+        deleted: subject.deleted,
         id: subject.id,
         myVote: subject.myVote,
         saved: subject.saved,
@@ -326,6 +327,7 @@ export class FakePiefedInstance extends FakeInstance {
         body: subject.content,
         child_count: subject.childCount,
         creator: person(subject.creator),
+        deleted: subject.deleted,
         id: subject.id,
         myVote: subject.myVote,
         path: subject.path,
@@ -560,6 +562,101 @@ export class FakePiefedInstance extends FakeInstance {
       const comment = findComment(comment_id);
       if (!comment) return notFound;
       comment.saved = save;
+      return { json: { comment_view: commentView(comment) } };
+    });
+
+    // Create/edit/delete writes mutate the seed store; the returned view and
+    // subsequent reads reflect the change. PieFed carries content as `body`
+    // and duplicates `name` as `title`.
+    this.mock("POST /api/alpha/post", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const wire = call.body as {
+        body?: string;
+        community_id: number;
+        name: string;
+        url?: string;
+      };
+      const community = seed.communities.find(
+        (candidate) => candidate.id === wire.community_id,
+      );
+      const post = seed.post({
+        body: wire.body,
+        community,
+        creator: seed.loggedInPerson,
+        name: wire.name,
+        url: wire.url,
+      });
+      return { json: { post_view: postView(post) } };
+    });
+
+    this.mock("PUT /api/alpha/post", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const wire = call.body as {
+        body?: string;
+        name?: string;
+        post_id: number;
+        url?: string;
+      };
+      const post = findPost(wire.post_id);
+      if (!post) return notFound;
+      if (wire.name !== undefined) post.name = wire.name;
+      if (wire.body !== undefined) post.body = wire.body;
+      if (wire.url !== undefined) post.url = wire.url;
+      return { json: { post_view: postView(post) } };
+    });
+
+    this.mock("POST /api/alpha/post/delete", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { deleted, post_id } = call.body as {
+        deleted: boolean;
+        post_id: number;
+      };
+      const post = findPost(post_id);
+      if (!post) return notFound;
+      post.deleted = deleted;
+      return { json: { post_view: postView(post) } };
+    });
+
+    this.mock("POST /api/alpha/comment", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const wire = call.body as {
+        body: string;
+        parent_id?: number;
+        post_id: number;
+      };
+      const post = findPost(wire.post_id);
+      if (!post) return notFound;
+      const parent = wire.parent_id ? findComment(wire.parent_id) : undefined;
+      const comment = seed.comment({
+        content: wire.body,
+        creator: seed.loggedInPerson,
+        post,
+      });
+      if (parent) comment.path = `${parent.path}.${comment.id}`;
+      return { json: { comment_view: commentView(comment) } };
+    });
+
+    this.mock("PUT /api/alpha/comment", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { body, comment_id } = call.body as {
+        body: string;
+        comment_id: number;
+      };
+      const comment = findComment(comment_id);
+      if (!comment) return notFound;
+      comment.content = body;
+      return { json: { comment_view: commentView(comment) } };
+    });
+
+    this.mock("POST /api/alpha/comment/delete", (call) => {
+      if (!seed.loggedInPerson) return unauthenticated;
+      const { comment_id, deleted } = call.body as {
+        comment_id: number;
+        deleted: boolean;
+      };
+      const comment = findComment(comment_id);
+      if (!comment) return notFound;
+      comment.deleted = deleted;
       return { json: { comment_view: commentView(comment) } };
     });
 

--- a/src/testing/seed.ts
+++ b/src/testing/seed.ts
@@ -15,6 +15,8 @@ export interface SeedComment {
   childCount: number;
   content: string;
   creator: SeedPerson;
+  /** Deleted by its creator (mutated by delete writes) */
+  deleted: boolean;
   id: number;
   /** The logged-in user's vote (mutated by like writes) */
   myVote: -1 | 0 | 1;
@@ -58,6 +60,8 @@ export interface SeedPost {
   body?: string;
   community: SeedCommunity;
   creator: SeedPerson;
+  /** Deleted by its creator (mutated by delete writes) */
+  deleted: boolean;
   id: number;
   /** The logged-in user's vote (mutated by like writes) */
   myVote: -1 | 0 | 1;
@@ -107,6 +111,7 @@ export class SeedStore {
     childCount?: number;
     content: string;
     creator?: SeedPerson;
+    deleted?: boolean;
     id?: number;
     myVote?: -1 | 0 | 1;
     path?: string;
@@ -122,6 +127,7 @@ export class SeedStore {
       childCount: over.childCount ?? 0,
       content: over.content,
       creator: over.creator ?? post.creator,
+      deleted: over.deleted ?? false,
       id,
       myVote: over.myVote ?? 0,
       path: over.path ?? `0.${id}`,
@@ -187,6 +193,7 @@ export class SeedStore {
     body?: string;
     community?: SeedCommunity;
     creator?: SeedPerson;
+    deleted?: boolean;
     id?: number;
     myVote?: -1 | 0 | 1;
     name: string;
@@ -198,6 +205,7 @@ export class SeedStore {
       body: over.body,
       community: over.community ?? this.#defaultCommunity(),
       creator: over.creator ?? this.#defaultPerson(),
+      deleted: over.deleted ?? false,
       id: over.id ?? this.#nextId++,
       myVote: over.myVote ?? 0,
       name: over.name,

--- a/test/testing-seed-matrix.test.ts
+++ b/test/testing-seed-matrix.test.ts
@@ -101,6 +101,59 @@ describe.each([
     expect(payloads[0]).toMatchObject({ limit: 7 });
   });
 
+  it("derives create/edit/delete write responses", async () => {
+    const { cats, client, fake, post } = setup();
+    fake.seed.loggedInAs(fake.seed.person({ id: 100, name: "me" }));
+
+    // Create a post → returned view + subsequent feed reflect it
+    const created = await client.createPost({
+      body: "fresh body",
+      community_id: cats.id,
+      name: "Fresh post",
+    });
+    expect(created.post_view.post.name).toBe("Fresh post");
+    expect(created.post_view.creator.name).toBe("me");
+    const { data: feed } = await client.getPosts({});
+    expect(feed.map((view) => view.post.name)).toContain("Fresh post");
+
+    // Edit the created post
+    const edited = await client.editPost({
+      name: "Edited post",
+      post_id: created.post_view.post.id,
+    });
+    expect(edited.post_view.post.name).toBe("Edited post");
+
+    // Delete it
+    const removed = await client.deletePost({
+      deleted: true,
+      post_id: created.post_view.post.id,
+    });
+    expect(removed.post_view.post.deleted).toBe(true);
+
+    // Create a comment → appears under the post
+    const comment = await client.createComment({
+      content: "a new reply",
+      post_id: post.id,
+    });
+    expect(comment.comment_view.comment.content).toBe("a new reply");
+    const { data: comments } = await client.getComments({ post_id: post.id });
+    expect(comments.map((view) => view.comment.content)).toContain(
+      "a new reply",
+    );
+
+    // Edit + delete the comment
+    const editedComment = await client.editComment({
+      comment_id: comment.comment_view.comment.id,
+      content: "edited reply",
+    });
+    expect(editedComment.comment_view.comment.content).toBe("edited reply");
+    const deletedComment = await client.deleteComment({
+      comment_id: comment.comment_view.comment.id,
+      deleted: true,
+    });
+    expect(deletedComment.comment_view.comment.deleted).toBe(true);
+  });
+
   it("derives vote/save state from write mutations", async () => {
     const { client, fake, post } = setup();
     fake.seed.loggedInAs(fake.seed.person({ name: "me" }));
@@ -129,6 +182,25 @@ describe.each([
     const saved = await client.savePost({ post_id: post.id, save: true });
     expect(saved.post_view.saved).toBe(true);
     expect((await client.getPost({ id: post.id })).post_view.saved).toBe(true);
+
+    // Comments mutate the same way
+    const comment = fake.seed.comment({ content: "hi", post });
+    const cLiked = await client.likeComment({
+      comment_id: comment.id,
+      is_upvote: true,
+    });
+    expect(cLiked.comment_view.my_vote).toBe(1);
+    expect(cLiked.comment_view.comment.score).toBe(2);
+
+    const cSaved = await client.saveComment({
+      comment_id: comment.id,
+      save: true,
+    });
+    expect(cSaved.comment_view.saved).toBe(true);
+    const { data: comments } = await client.getComments({ post_id: post.id });
+    const reread = comments.find((view) => view.comment.id === comment.id);
+    expect(reread?.saved).toBe(true);
+    expect(reread?.my_vote).toBe(1);
   });
 
   it("rejects account endpoints when nobody is logged in", async () => {


### PR DESCRIPTION
Wave 3 #6 — the highest-value follow-up: derived write responses unblock the most pinned Voyager specs (composing's reply-renders, edit-updates-thread, delete-removes, create-navigates).

Seed posts/comments gain a mutable `deleted` flag. The fakes derive `createPost` / `createComment` / `editPost` / `editComment` / `deletePost` / `deleteComment`: they mutate the seed store (new entities show up in `getPosts`/`getComments`, edits change content, deletes set the flag) and return the updated view. Comments created with `parent_id` nest via path. Auth-gated; both providers (v1 uses `body`→content and DELETE verbs; PieFed uses `body`/`title` and POST `/delete` routes).

Provider-matrix test drives the full create→edit→delete cycle for posts and comments through a real client on both lemmyv1 and piefed. Also folds in the comment like/save end-to-end coverage that was reviewed in #69 but merged before it landed.

438 tests, typecheck, lint, build clean.