### PR TITLE
feat: expose every recorded call on fake instances

### DIFF
--- a/src/testing/FakeInstance.ts
+++ b/src/testing/FakeInstance.ts
@@ -185,6 +185,18 @@ export class FakeInstance {
     });
   }
 
+  /**
+   * Every request this instance received, in order.
+   *
+   * For "nothing was sent" claims: asserting a specific route was never
+   * called can't fail if the client has no way to call it, whereas
+   * comparing this list before and after an action genuinely checks that
+   * the action stayed local.
+   */
+  allCalls(): RecordedCall[] {
+    return [...this.#calls];
+  }
+
   /** All recorded requests matching `"METHOD /path"` (query ignored). */
   calls(matcher: Matcher): RecordedCall[] {
     return this.#calls.filter(

--- a/test/testing-fake-instance.test.ts
+++ b/test/testing-fake-instance.test.ts
@@ -137,6 +137,20 @@ describe("FakeLemmyV1Instance + ThreadiverseClient round trip", () => {
     ]);
   });
 
+  it("exposes every recorded call for 'nothing was sent' assertions", async () => {
+    const { client, instance } = setup();
+
+    await client.getPosts({});
+    const before = instance.allCalls().length;
+
+    // A local-only action must not add requests
+    expect(instance.allCalls()).toHaveLength(before);
+    expect(instance.allCalls().at(-1)?.pathname).toBe("/api/v4/post/list");
+
+    await client.getPosts({});
+    expect(instance.allCalls().length).toBe(before + 1);
+  });
+
   it("records calls with query for assertions", async () => {
     const { client, instance } = setup();
 


### PR DESCRIPTION
`allCalls()` makes "this action stayed local" testable. Asserting a specific route was never called can't fail when the client has no way to call it — a consumer spec was doing exactly that, an unfalsifiable assertion that also pinned an otherwise provider-agnostic test to one provider. Comparing recorded calls before and after an action checks the real claim.